### PR TITLE
Fill merge request

### DIFF
--- a/src/GitLabHealth-Model-Importer/GLHModelImporter.class.st
+++ b/src/GitLabHealth-Model-Importer/GLHModelImporter.class.st
@@ -739,8 +739,9 @@ GLHModelImporter >> importRepository: aGLHRepository [
 GLHModelImporter >> importUser: aUserID [
 
 	| result userResult |
-
-	(glhModel allWithType: GLHUser) asOrderedCollection detect: [ :user | user id = aUserID ] ifFound: [ :user | ^ user ].
+	(glhModel allWithType: GLHUser) asOrderedCollection
+		detect: [ :user | user id = aUserID ]
+		ifFound: [ :user | ^ user ].
 	('Import user: ' , aUserID printString) recordInfo.
 	result := self glhApi user: aUserID.
 	userResult := self parseUserResult: result.
@@ -763,7 +764,10 @@ GLHModelImporter >> importUserByUsername: anUsername [
 
 		  (searchResult class = Dictionary and: [
 			   (searchResult at: #message) includesSubstring: '403 Forbidden' ])
-			  ifTrue: [ glhModel add: (GLHUser new username: anUsername) unless: [ :nu :ou | nu username = ou username ] ]
+			  ifTrue: [
+				  glhModel
+					  add: (GLHUser new username: anUsername)
+					  unless: [ :nu :ou | nu username = ou username ] ]
 			  ifFalse: [
 				  searchResult
 					  ifEmpty: [

--- a/src/GitLabProjectHealth-Model-Importer-Tests/GLPHApiMock.class.st
+++ b/src/GitLabProjectHealth-Model-Importer-Tests/GLPHApiMock.class.st
@@ -8,6 +8,7 @@ Class {
 GLPHApiMock >> mergeRequestOfProject: project withId: id [
 
 	^ '{
-	"author":{ "id": 12 }
+	"author":{ "id": 12 },
+	"merge_user":{ "id": 12 }
 }'
 ]

--- a/src/GitLabProjectHealth-Model-Importer-Tests/GLPHApiMock.class.st
+++ b/src/GitLabProjectHealth-Model-Importer-Tests/GLPHApiMock.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #GLPHApiMock,
+	#superclass : #GLPHApi,
+	#category : #'GitLabProjectHealth-Model-Importer-Tests'
+}
+
+{ #category : #'as yet unclassified' }
+GLPHApiMock >> mergeRequestOfProject: project withId: id [
+
+	^ '{
+	"author":{ "id": 12 }
+}'
+]

--- a/src/GitLabProjectHealth-Model-Importer-Tests/GLPHModelImporterMergeRequestTest.class.st
+++ b/src/GitLabProjectHealth-Model-Importer-Tests/GLPHModelImporterMergeRequestTest.class.st
@@ -1,0 +1,111 @@
+Class {
+	#name : #GLPHModelImporterMergeRequestTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'githubDiffData',
+		'gitlabDiffData',
+		'glhImporter',
+		'gitlabMergeData'
+	],
+	#category : #'GitLabProjectHealth-Model-Importer-Tests'
+}
+
+{ #category : #running }
+GLPHModelImporterMergeRequestTest >> setUp [
+
+	super setUp.
+	glhImporter := GLPHModelImporter new.
+	gitlabMergeData := '[
+		{"id":46074,
+		"iid":1415,
+		"project_id":4810,
+		"title":"Super MR",
+		"description":"Close Issue XX",
+		"state":"opened",
+		"created_at":"2024-07-01T16:05:48.775+02:00",
+		"updated_at":"2024-07-01T16:05:51.221+02:00",
+		"merged_by":null,
+		"merge_user":null,
+		"merged_at":null,
+		"closed_by":null,
+		"closed_at":null,
+		"target_branch":"1.0.0",
+		"source_branch":"feature/XX",
+		"user_notes_count":0,
+		"upvotes":0,
+		"downvotes":0,
+		"author":
+			{
+				"id":12,
+				"username":"badetitou",
+				"name":"Verhaeghe Benoit",
+				"state":"active",
+				"avatar_url":"https://gitlab.com/badetitou.png",
+				"web_url":"https://gitlab.com/badetitou"
+			},
+		"assignees":[
+			{
+			"id":12,
+			"username":"badetitou",
+			"name":"Verhaeghe Benoit",
+			"state":"active",
+			"avatar_url":"https://gitlab.com/badetitou.png",
+			"web_url":"https://gitlab.com/badetitou"
+			}
+		],
+		"assignee":{
+			"id":12,
+			"username":"badetitou",
+			"name":"Verhaeghe Benoit",
+			"state":"active",
+			"avatar_url":"https://gitlab.com/badetitou.png",
+			"web_url":"https://gitlab.com/badetitou"
+		},
+		"reviewers":[],
+		"source_project_id":4810,
+		"target_project_id":4810,
+		"labels":[],
+		"draft":false,
+		"work_in_progress":false,
+		"milestone":null,
+		"merge_when_pipeline_succeeds":false,
+		"merge_status":"can_be_merged",
+		"detailed_merge_status":"mergeable",
+		"sha":"idgyuzegfdyugfzuygdiuezg",
+		"merge_commit_sha":null,
+		"squash_commit_sha":null,
+		"discussion_locked":null,
+		"should_remove_source_branch":null,
+		"force_remove_source_branch":true,
+		"reference":"!1024",
+		"references":{
+			"short":"!1415",
+			"relative":"!1415",
+			"full":"group/group2!1415"
+		},
+		"web_url":"https://gitlab.com/group/group2/-/merge_requests/1415",
+		"time_stats":{
+			"time_estimate":0,
+			"total_time_spent":0,
+			"human_time_estimate":null,
+			"human_total_time_spent":null
+		},
+		"squash":true,
+		"squash_on_merge":true,
+		"task_completion_status":{
+			"count":0,
+			"completed_count":0
+		},
+		"has_conflicts":false,
+		"blocking_discussions_resolved":true
+}]'
+]
+
+{ #category : #test }
+GLPHModelImporterMergeRequestTest >> testParseMergeRequestResult [
+
+	| parseRes |
+	parseRes := glhImporter parseMergeRequestResult: gitlabMergeData.
+	self assert: parseRes size equals: 1.
+	self assert: parseRes anyOne id equals: 46074
+]

--- a/src/GitLabProjectHealth-Model-Importer-Tests/GLPHModelImporterMergeRequestTest.class.st
+++ b/src/GitLabProjectHealth-Model-Importer-Tests/GLPHModelImporterMergeRequestTest.class.st
@@ -29,7 +29,14 @@ GLPHModelImporterMergeRequestTest >> setUp [
 		"created_at":"2024-07-01T16:05:48.775+02:00",
 		"updated_at":"2024-07-01T16:05:51.221+02:00",
 		"merged_by":null,
-		"merge_user":null,
+		"merge_user":{
+				"id":12,
+				"username":"badetitou",
+				"name":"Verhaeghe Benoit",
+				"state":"active",
+				"avatar_url":"https://gitlab.com/badetitou.png",
+				"web_url":"https://gitlab.com/badetitou"
+			},
 		"merged_at":null,
 		"closed_by":null,
 		"closed_at":null,
@@ -103,6 +110,49 @@ GLPHModelImporterMergeRequestTest >> setUp [
 		"has_conflicts":false,
 		"blocking_discussions_resolved":true
 }]'
+]
+
+{ #category : #test }
+GLPHModelImporterMergeRequestTest >> testParseMergeRequestMergeUserAlreadySet [
+
+	| mergeRequest user |
+	mergeRequest := (glhImporter parseMergeRequestResult: gitlabMergeData) anyOne.
+	user := GLHUser new.
+	mergeRequest merge_user: user.
+	glhImporter importMergeResquestMerger: mergeRequest.
+	self assert: mergeRequest merge_user equals: user
+]
+
+{ #category : #test }
+GLPHModelImporterMergeRequestTest >> testParseMergeRequestMergeUserExistInModelAndCacheID [
+
+	| mergeRequest user |
+	mergeRequest := (glhImporter parseMergeRequestResult: gitlabMergeData)
+		                anyOne.
+	user := glhModel newUser.
+	user id: 12.
+	glhImporter importMergeResquestMerger: mergeRequest.
+	self assert: mergeRequest merge_user equals: user
+]
+
+{ #category : #test }
+GLPHModelImporterMergeRequestTest >> testParseMergeRequestMergeUserIsNil [
+
+	| mergeRequest |
+	mergeRequest := (glhImporter parseMergeRequestResult: '[{"id":46074}]') anyOne.
+	self assert: mergeRequest merge_user equals: nil
+]
+
+{ #category : #test }
+GLPHModelImporterMergeRequestTest >> testParseMergeRequestMergeUserWithoutCache [
+
+	| mergeRequest user |
+	mergeRequest := (glhImporter parseMergeRequestResult: gitlabMergeData) anyOne.
+	mergeRequest flush.
+	user := glhModel newUser.
+	user id: 12.
+	glhImporter importMergeResquestMerger: mergeRequest.
+	self assert: mergeRequest merge_user equals: user
 ]
 
 { #category : #test }

--- a/src/GitLabProjectHealth-Model-Importer-Tests/GLPHModelImporterMergeRequestTest.class.st
+++ b/src/GitLabProjectHealth-Model-Importer-Tests/GLPHModelImporterMergeRequestTest.class.st
@@ -16,6 +16,7 @@ GLPHModelImporterMergeRequestTest >> setUp [
 
 	super setUp.
 	glhImporter := GLPHModelImporter new.
+	glhImporter glhApi: GLPHApiMock new.
 	glhModel := GLPHEModel new.
 	glhImporter glhModel: glhModel.
 	gitlabMergeData := '[
@@ -130,6 +131,19 @@ GLPHModelImporterMergeRequestTest >> testParseMergeRequestUserExistInModelAndCac
 	| mergeRequest user |
 	mergeRequest := (glhImporter parseMergeRequestResult: gitlabMergeData)
 		                anyOne.
+	user := glhModel newUser.
+	user id: 12.
+	glhImporter importMergeResquestAuthor: mergeRequest.
+	self assert: mergeRequest author equals: user
+]
+
+{ #category : #test }
+GLPHModelImporterMergeRequestTest >> testParseMergeRequestWithoutCache [
+
+	| mergeRequest user |
+	mergeRequest := (glhImporter parseMergeRequestResult: gitlabMergeData)
+		                anyOne.
+	mergeRequest flush.
 	user := glhModel newUser.
 	user id: 12.
 	glhImporter importMergeResquestAuthor: mergeRequest.

--- a/src/GitLabProjectHealth-Model-Importer-Tests/GLPHModelImporterMergeRequestTest.class.st
+++ b/src/GitLabProjectHealth-Model-Importer-Tests/GLPHModelImporterMergeRequestTest.class.st
@@ -5,7 +5,8 @@ Class {
 		'githubDiffData',
 		'gitlabDiffData',
 		'glhImporter',
-		'gitlabMergeData'
+		'gitlabMergeData',
+		'glhModel'
 	],
 	#category : #'GitLabProjectHealth-Model-Importer-Tests'
 }
@@ -15,6 +16,8 @@ GLPHModelImporterMergeRequestTest >> setUp [
 
 	super setUp.
 	glhImporter := GLPHModelImporter new.
+	glhModel := GLPHEModel new.
+	glhImporter glhModel: glhModel.
 	gitlabMergeData := '[
 		{"id":46074,
 		"iid":1415,
@@ -108,4 +111,27 @@ GLPHModelImporterMergeRequestTest >> testParseMergeRequestResult [
 	parseRes := glhImporter parseMergeRequestResult: gitlabMergeData.
 	self assert: parseRes size equals: 1.
 	self assert: parseRes anyOne id equals: 46074
+]
+
+{ #category : #test }
+GLPHModelImporterMergeRequestTest >> testParseMergeRequestUserAlreadySet [
+
+	| mergeRequest user |
+	mergeRequest := (glhImporter parseMergeRequestResult: gitlabMergeData) anyOne.
+	user := GLHUser new.
+	mergeRequest author: user.
+	glhImporter importMergeResquestAuthor: mergeRequest.
+	self assert: mergeRequest author equals: user
+]
+
+{ #category : #test }
+GLPHModelImporterMergeRequestTest >> testParseMergeRequestUserExistInModelAndCacheID [
+
+	| mergeRequest user |
+	mergeRequest := (glhImporter parseMergeRequestResult: gitlabMergeData)
+		                anyOne.
+	user := glhModel newUser.
+	user id: 12.
+	glhImporter importMergeResquestAuthor: mergeRequest.
+	self assert: mergeRequest author equals: user
 ]

--- a/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
+++ b/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
@@ -118,13 +118,20 @@ GLPHModelImporter >> configureReaderForMergeRequest: reader [
 		(mapping mapInstVar: #merged_at) valueSchema: DateAndTime.
 		(mapping mapInstVar: #closed_at) valueSchema: DateAndTime.
 		"(mapping mapInstVar: #assignee) valueSchema: GLHUser."
-		(mapping
-			 mapProperty: #author
-			 getter: [  ]
-			 setter: [ :object :value | object cacheAt: #authorID put: (value at: #id) ]).
-		"(mapping mapInstVar: #closed_by) valueSchema: GLHUser.
-		(mapping mapInstVar: #mergeCommit) valueSchema: GLHCommit." ].
+		mapping
+			mapProperty: #author
+			getter: [  ]
+			setter: [ :object :value |
+			object cacheAt: #authorID put: (value at: #id) ].
+		mapping
+			mapProperty: #merge_user
+			getter: [  ]
+			setter: [ :object :value | 
+				value ifNotNil: [
+					object cacheAt: #mergeUserID put: (value at: #id) ] ] ].
 
+	"(mapping mapInstVar: #closed_by) valueSchema: GLHUser.
+	(mapping mapInstVar: #mergeCommit) valueSchema: GLHCommit."
 	"indique ce que doit faire le reader lorsqu'il parse une DateAndTime object"
 	reader for: DateAndTime customDo: [ :mapping |
 		mapping decoder: [ :string |
@@ -352,6 +359,21 @@ GLPHModelImporter >> importMergeResquestAuthor: aGLPHEMergeRequest [
 					              withId: aGLPHEMergeRequest iid) readStream;
 			             next) at: #author at: #id ].
 	aGLPHEMergeRequest author: (self importUser: authorID)
+]
+
+{ #category : #'import - merge request' }
+GLPHModelImporter >> importMergeResquestMerger: aGLPHEMergeRequest [
+
+	| authorID |
+	aGLPHEMergeRequest merge_user ifNotNil: [ ^ aGLPHEMergeRequest merge_user ].
+	authorID := aGLPHEMergeRequest cacheAt: #mergeUserID ifAbsent: [
+		            (generalReader
+			             on: (self glhApi
+					              mergeRequestOfProject:
+						              aGLPHEMergeRequest project_id
+					              withId: aGLPHEMergeRequest iid) readStream;
+			             next) at: #merge_user at: #id ].
+	aGLPHEMergeRequest merge_user: (self importUser: authorID)
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
+++ b/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
@@ -116,51 +116,13 @@ GLPHModelImporter >> configureReaderForMergeRequest: reader [
 		(mapping mapInstVar: #created_at) valueSchema: DateAndTime.
 		(mapping mapInstVar: #updated_at) valueSchema: DateAndTime.
 		(mapping mapInstVar: #merged_at) valueSchema: DateAndTime.
-		(mapping mapInstVar: #closed_at) valueSchema: DateAndTime
-		"		
-		(mapping mapInstVar: #assignee) valueSchema: GLHUser.
-		(mapping mapInstVar: #author) valueSchema: GLHUser.
-		(mapping mapInstVar: #closed_by) valueSchema: GLHUser.
-		(mapping mapInstVar: #mergeCommit) valueSchema: GLHCommit." ].
-
-	"indique ce que doit faire le reader lorsqu'il parse une DateAndTime object"
-	reader for: DateAndTime customDo: [ :mapping |
-		mapping decoder: [ :string |
-			string ifNil: [ nil ] ifNotNil: [ DateAndTime fromString: string ] ] ]
-]
-
-{ #category : #'private - configure reader' }
-GLPHModelImporter >> configureReaderForMergeRequestApproval: reader [
-	"declare quil y a un array a mapper"
-
-	reader for: #ArrayOfMergeRequest customDo: [ :customMappting |
-		customMappting listOfElementSchema: GLPHEMergeRequest ].
-
-	"declare la liste des properties"
-	reader for: GLPHEMergeRequest do: [ :mapping |
-		mapping mapInstVars:
-			#( blocking_discussions_resolved changes_count description
-			   detailed_merge_status discussion_locked downvotes draft first_deployed_to_production_at
-			   force_remove_source_branch has_conflicts id iid labels latest_build_finished_at
-			   latest_build_started_at merge_commit_sha merge_status
-			   merge_when_pipeline_succeeds merged_at milestone project_id
-			   reference references_full references_relative
-			   references_short sha should_remove_source_branch
-			   source_branch source_project_id squash squash_commit_sha
-			   squash_on_merge state subscribed target_branch target_project_id
-			   task_completion_status_completed_count
-			   task_completion_status_count time_stats_human_time_estimate
-			   time_stats_human_total_time_spent
-			   time_stats_time_estimate time_stats_total_time_spent
-			   title updated_at upvotes user_notes_count web_url work_in_progress ).
-		(mapping mapInstVar: #created_at) valueSchema: DateAndTime.
-		(mapping mapInstVar: #updated_at) valueSchema: DateAndTime.
-		(mapping mapInstVar: #merged_at) valueSchema: DateAndTime.
-		(mapping mapInstVar: #closed_at) valueSchema: DateAndTime
-		"		
-		(mapping mapInstVar: #assignee) valueSchema: GLHUser.
-		(mapping mapInstVar: #author) valueSchema: GLHUser.
-		(mapping mapInstVar: #closed_by) valueSchema: GLHUser.
+		(mapping mapInstVar: #closed_at) valueSchema: DateAndTime.
+		"(mapping mapInstVar: #assignee) valueSchema: GLHUser."
+		(mapping
+			 mapProperty: #author
+			 getter: [  ]
+			 setter: [ :object :value | object cacheAt: #authorID put: (value at: #id) ]).
+		"(mapping mapInstVar: #closed_by) valueSchema: GLHUser.
 		(mapping mapInstVar: #mergeCommit) valueSchema: GLHCommit." ].
 
 	"indique ce que doit faire le reader lorsqu'il parse une DateAndTime object"
@@ -369,6 +331,10 @@ GLPHModelImporter >> importMergeResquestApprovals: aGLPHEMergeRequest [
 	parsedResult := generalReader
 		                on: results readStream;
 		                next.
+
+	(parsedResult at: #approved_by) do: [ :approvedUser |
+		aGLPHEMergeRequest addApproved_by:
+			(self importUser: ((approvedUser at: #user) at: #id)) ].
 	aGLPHEMergeRequest approved: (parsedResult at: #approved).
 	^ aGLPHEMergeRequest
 ]

--- a/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
+++ b/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
@@ -243,7 +243,7 @@ GLPHModelImporter >> importDiffRangesForDiff: aGLHDiff [
 		  unless: self blockForDiffRangeEquality
 ]
 
-{ #category : #import }
+{ #category : #'import - merge request' }
 GLPHModelImporter >> importMergeRequests: aGLHProject [
 
 	| results parsedResults |
@@ -272,7 +272,7 @@ GLPHModelImporter >> importMergeRequests: aGLHProject [
 			self importDiffOfMergeRequest: mr ] ]
 ]
 
-{ #category : #import }
+{ #category : #'import - merge request' }
 GLPHModelImporter >> importMergeRequests: aGLHProject since: fromDate until: toDate [
 
 	| newlyFoundMR page foundMR |
@@ -317,7 +317,7 @@ GLPHModelImporter >> importMergeRequests: aGLHProject since: fromDate until: toD
 	^ foundMR
 ]
 
-{ #category : #import }
+{ #category : #'import - merge request' }
 GLPHModelImporter >> importMergeResquestApprovals: aGLPHEMergeRequest [
 
 	| results parsedResult |
@@ -337,6 +337,20 @@ GLPHModelImporter >> importMergeResquestApprovals: aGLPHEMergeRequest [
 			(self importUser: ((approvedUser at: #user) at: #id)) ].
 	aGLPHEMergeRequest approved: (parsedResult at: #approved).
 	^ aGLPHEMergeRequest
+]
+
+{ #category : #'import - merge request' }
+GLPHModelImporter >> importMergeResquestAuthor: aGLPHEMergeRequest [
+
+	| authorID |
+	aGLPHEMergeRequest author ifNotNil: [ ^ aGLPHEMergeRequest author ].
+	authorID := aGLPHEMergeRequest cacheAt: #authorID ifAbsent: [
+		            (self glhApi
+			             mergeRequestOfProject: aGLPHEMergeRequest project_id
+			             withId: aGLPHEMergeRequest iid) next
+			            at: #author
+			            at: #id ].
+	aGLPHEMergeRequest author: (self importUser: authorID)
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
+++ b/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
@@ -345,11 +345,12 @@ GLPHModelImporter >> importMergeResquestAuthor: aGLPHEMergeRequest [
 	| authorID |
 	aGLPHEMergeRequest author ifNotNil: [ ^ aGLPHEMergeRequest author ].
 	authorID := aGLPHEMergeRequest cacheAt: #authorID ifAbsent: [
-		            (self glhApi
-			             mergeRequestOfProject: aGLPHEMergeRequest project_id
-			             withId: aGLPHEMergeRequest iid) next
-			            at: #author
-			            at: #id ].
+		            (generalReader
+			             on: (self glhApi
+					              mergeRequestOfProject:
+						              aGLPHEMergeRequest project_id
+					              withId: aGLPHEMergeRequest iid) readStream;
+			             next) at: #author at: #id ].
 	aGLPHEMergeRequest author: (self importUser: authorID)
 ]
 

--- a/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
+++ b/src/GitLabProjectHealth-Model-Importer/GLPHModelImporter.class.st
@@ -365,14 +365,18 @@ GLPHModelImporter >> importMergeResquestAuthor: aGLPHEMergeRequest [
 GLPHModelImporter >> importMergeResquestMerger: aGLPHEMergeRequest [
 
 	| authorID |
-	aGLPHEMergeRequest merge_user ifNotNil: [ ^ aGLPHEMergeRequest merge_user ].
+	aGLPHEMergeRequest merge_user ifNotNil: [
+		^ aGLPHEMergeRequest merge_user ].
 	authorID := aGLPHEMergeRequest cacheAt: #mergeUserID ifAbsent: [
 		            (generalReader
 			             on: (self glhApi
 					              mergeRequestOfProject:
 						              aGLPHEMergeRequest project_id
 					              withId: aGLPHEMergeRequest iid) readStream;
-			             next) at: #merge_user at: #id ].
+			             next)
+			            at: #merge_user
+			            ifPresent: [ :mergeUser |
+			            mergeUser ifNotNil: [ :mruser | mruser at: #id ] ] ].
 	aGLPHEMergeRequest merge_user: (self importUser: authorID)
 ]
 


### PR DESCRIPTION
This PR aims to add a method to add the merge request author in a three steps approach

First search if the data is already present
Second, search is the cache gives us hint of the user
Last, perform again request

The idea is to avoid API requests.

I also added tests for these feature