### PR TITLE
optimize also the `addAll:ofType:unless:` and add similar tests

### DIFF
--- a/src/GitLabHealth-Model-Extension-Tests/GLHExtensionTest.class.st
+++ b/src/GitLabHealth-Model-Extension-Tests/GLHExtensionTest.class.st
@@ -17,12 +17,39 @@ GLHExtensionTest >> setUp [
 { #category : #tests }
 GLHExtensionTest >> testAddAllOfTypeUnless [
 
-	| user values |
-	user := GLHUser new.
-	user id: 12.
-	values := model addAll: { user } ofType: GLHUser unless: [ :a :b | a id = b id ].
-	self assert: values size equals: 1.
-	self assert: values anyOne equals: user.
+
+	| user1 user2 user3 user2b user3b user4 result |
+	user1 := GLHUser new.
+	user1 id: 1.
+	user2 := GLHUser new.
+	user2 id: 2.
+	user3 := GLHUser new.
+	user3 id: 3.
+	model
+		addAll: {
+				user1.
+				user2.
+				user3 }
+		unless: [ :a :b | a id = b id ].
+	self assert: model size equals: 3.
+	user2b := GLHUser new.
+	user2b id: 2.
+	user3b := GLHUser new.
+	user3b id: 3.
+	user4 := GLHUser new.
+	user4 id: 4.
+
+	result := model
+		          addAll: {
+				          user2b.
+				          user3b.
+				          user4 }
+		          unless: [ :a :b | a id = b id ].
+	self assert: model size equals: 4.
+	self assert: result size equals: 3.
+	self assert: (result includes: user2).
+	self assert: (result includes: user3).
+	self assert: (result includes: user4)
 ]
 
 { #category : #tests }

--- a/src/GitLabHealth-Model-Extension-Tests/GLHExtensionTest.class.st
+++ b/src/GitLabHealth-Model-Extension-Tests/GLHExtensionTest.class.st
@@ -17,6 +17,36 @@ GLHExtensionTest >> setUp [
 { #category : #tests }
 GLHExtensionTest >> testAddAllOfTypeUnless [
 
+	| user values |
+	user := GLHUser new.
+	user id: 12.
+	values := model addAll: { user } ofType: GLHUser unless: [ :a :b | a id = b id ].
+	self assert: values size equals: 1.
+	self assert: values anyOne equals: user.
+]
+
+{ #category : #tests }
+GLHExtensionTest >> testAddAllOfTypeUnlessDifferentEntity [
+
+	| user values alreadyExistingUser |
+	alreadyExistingUser := model newUser.
+	alreadyExistingUser id: 15.
+	user := GLHUser new.
+	user id: 12.
+	values := model
+		          addAll: { user }
+		          ofType: GLHUser
+		          unless: [ :a :b | a id = b id ].
+	self assert: values size equals: 1.
+	self assert: model size equals: 2.
+	self assert: (values includes: user).
+	self assert: (model includes: user).
+	self assert: (model includes: alreadyExistingUser)
+]
+
+{ #category : #tests }
+GLHExtensionTest >> testAddAllOfTypeUnlessIntersection [
+
 
 	| user1 user2 user3 user2b user3b user4 result |
 	user1 := GLHUser new.
@@ -50,25 +80,6 @@ GLHExtensionTest >> testAddAllOfTypeUnless [
 	self assert: (result includes: user2).
 	self assert: (result includes: user3).
 	self assert: (result includes: user4)
-]
-
-{ #category : #tests }
-GLHExtensionTest >> testAddAllOfTypeUnlessDifferentEntity [
-
-	| user values alreadyExistingUser |
-	alreadyExistingUser := model newUser.
-	alreadyExistingUser id: 15.
-	user := GLHUser new.
-	user id: 12.
-	values := model
-		          addAll: { user }
-		          ofType: GLHUser
-		          unless: [ :a :b | a id = b id ].
-	self assert: values size equals: 1.
-	self assert: model size equals: 2.
-	self assert: (values includes: user).
-	self assert: (model includes: user).
-	self assert: (model includes: alreadyExistingUser)
 ]
 
 { #category : #tests }

--- a/src/GitLabHealth-Model-Extension/MooseAbstractGroup.extension.st
+++ b/src/GitLabHealth-Model-Extension/MooseAbstractGroup.extension.st
@@ -10,17 +10,21 @@ MooseAbstractGroup >> add: anElmt unless: aConditionAsBlock [
 { #category : #'*GitLabHealth-Model-Extension' }
 MooseAbstractGroup >> addAll: anElmtCollection ofType: aType unless: aConditionAsBlock [
 
-	| addedElement |
-	addedElement := anElmtCollection reject: [ :anElmt |
-		                (self allWithType: aType) anySatisfy: [
-			                :existingElmt |
-			                aConditionAsBlock value: existingElmt value: anElmt ] ].
+	| originalCollection returnCollection |
+	originalCollection := (self allWithType: aType).
+	"Create same kind of collection"
+	returnCollection := self species new.
+	
+	anElmtCollection do: [ :anElmt |
+		originalCollection
+			detect: [ :existingElmt |
+			aConditionAsBlock value: existingElmt value: anElmt ]
+			ifFound: [ :el | returnCollection add: el ]
+			ifNone: [
+				returnCollection add: anElmt.
+				self add: anElmt ] ].
 
-	self addAll: addedElement.
-
-	^ (self allWithType: aType) select: [ :existingElmt |
-		  anElmtCollection anySatisfy: [ :anElmt |
-			  aConditionAsBlock value: anElmt value: existingElmt ] ]
+	^ returnCollection
 ]
 
 { #category : #'*GitLabHealth-Model-Extension' }


### PR DESCRIPTION
mimic optimization made in PR #12  for `addAll:ofType:unless:`

See benchmark

```st
users := MooseGroup new.
1 to: 300 do: [ :idx |
	| user |
	user := GLHUser new.
	user id: idx. 
	users add: user ].

[	user2b := GLHUser new.
	user2b id: 298.
	user3b := GLHUser new.
	user3b id: 300.
	user4 := GLHUser new.
	user4 id: 302.

	result := users
		          addAll: {
				          user2b.
				          user3b.
				          user4 }
		          unless: [ :a :b | a id = b id ]] bench
"'15 161.335 per second'"

"'44 587.330 per second'"

```