### PR TITLE
add documentor variable for Pharo 12 Ci execution

### DIFF
--- a/ci/generatePUML.st
+++ b/ci/generatePUML.st
@@ -1,3 +1,5 @@
+| documentor |
+
 documentor := FamixUMLDocumentor new.
 documentor
 	model: GLHModel color: Color white;


### PR DESCRIPTION
This PR adds the variable in the puml file. 
This is for documentation purpose only so move directly to main