### PR TITLE
add calculate link MR|Commit and jira

### DIFF
--- a/src/GitLabHealth-Model-Analysis-Tests/CommitLinkedToJiraProjectMetricTest.class.st
+++ b/src/GitLabHealth-Model-Analysis-Tests/CommitLinkedToJiraProjectMetricTest.class.st
@@ -1,0 +1,177 @@
+"
+A MergeRequestLinkedToJiraProjectMetricTest is a test class for testing the behavior of MergeRequestLinkedToJiraProjectMetric
+"
+Class {
+	#name : #CommitLinkedToJiraProjectMetricTest,
+	#superclass : #ProjectMetricTest,
+	#category : #'GitLabHealth-Model-Analysis-Tests'
+}
+
+{ #category : #tests }
+CommitLinkedToJiraProjectMetricTest >> testCalculate [
+
+	| result glhImporter jiraImporter commitsLinked jiraIssue commitMerged commit1 |
+	glhImporter := GLPHImporterMock new.
+
+	commit1 := GLHCommit new
+		           id: 1;
+		           message: '[TI-202] hello world';
+		           created_at: createdAt;
+		           committed_date: createdAt;
+		           repository: project1 repository;
+		           deletions: 5.
+
+	commitMerged := GLHCommit new
+		                id: 2;
+		                created_at: createdAt + 1 minutes;
+		                committed_date: createdAt + 1 minutes;
+		                repository: project1 repository;
+		                deletions: 5.
+	"those commits will be added to the MR with the mock importer"
+	glhImporter commits: { commit1 }.
+
+	jiraImporter := JiraImporterMock new.
+	jiraIssue := JPIssue new
+		             id: 'TI-202';
+		             key: 'TI-202';
+		             timeEstimate: 25 hours;
+		             yourself.
+	jiraImporter issues: { jiraIssue }.
+
+	commitsLinked := CommitLinkedToJiraProjectMetric new
+		                    project: project1;
+		                    glhImporter: glhImporter;
+		                    jiraImporter: jiraImporter;
+		                    setPeriodSince: since until: until;
+		                    over: Week.
+
+	result := commitsLinked calculate.
+
+	self assert: result equals: 1
+]
+
+{ #category : #tests }
+CommitLinkedToJiraProjectMetricTest >> testCalculateSeveral [
+
+	| result glhImporter jiraImporter jiraIssue commitMerged commit1 jiraIssue2 commitMerged2 jiraLinked |
+	glhImporter := GLPHImporterMock new.
+
+	commit1 := GLHCommit new
+		           id: 1;
+		           message: '';
+		           created_at: createdAt;
+		           committed_date: createdAt;
+		           repository: project1 repository;
+		           deletions: 5.
+
+	commitMerged := GLHCommit new
+		                id: 2;
+		                message: 'TI-206 hello';
+		                created_at: createdAt + 1 minutes;
+		                committed_date: createdAt + 1 minutes;
+		                repository: project1 repository;
+		                deletions: 5.
+
+	commitMerged2 := GLHCommit new
+		                 id: 3;
+		                 message: 'TI-205 blip blop';
+		                 created_at: createdAt + 1 minutes;
+		                 committed_date: createdAt + 1 minutes;
+		                 repository: project1 repository;
+		                 deletions: 5.
+
+	"those commits will be added to the MR with the mock importer"
+	glhImporter commits: {
+			commit1.
+			commitMerged.
+			commitMerged2 }.
+
+	jiraImporter := JiraImporterMock new.
+	jiraIssue := JPIssue new
+		             id: 'TI-205';
+		             key: 'TI-205';
+		             timeEstimate: 25 hours;
+		             yourself.
+	jiraIssue2 := JPIssue new
+		              id: 'TI-206';
+		              key: 'TI-206';
+		              timeEstimate: 25 hours;
+		              yourself.
+	jiraImporter issues: {
+			jiraIssue.
+			jiraIssue2 }.
+
+	jiraLinked := CommitLinkedToJiraProjectMetric new
+		              project: project1;
+		              glhImporter: glhImporter;
+		              jiraImporter: jiraImporter;
+		              setPeriodSince: since until: until;
+		              over: Week.
+
+	result := jiraLinked calculate.
+
+	self assert: result equals: 2
+]
+
+{ #category : #tests }
+CommitLinkedToJiraProjectMetricTest >> testCalculateSeveralWithOnlyError [
+
+	| result glhImporter jiraImporter jiraIssue commitMerged commit1 jiraIssue2 commitMerged2 jiraLinked |
+	glhImporter := GLPHImporterMock new.
+
+	commit1 := GLHCommit new
+		           id: 1;
+		           message: '';
+		           created_at: createdAt;
+		           committed_date: createdAt;
+		           repository: project1 repository;
+		           deletions: 5.
+
+	commitMerged := GLHCommit new
+		                id: 2;
+		                message: '';
+		                created_at: createdAt + 1 minutes;
+		                committed_date: createdAt + 1 minutes;
+		                repository: project1 repository;
+		                deletions: 5.
+
+	commitMerged2 := GLHCommit new
+		                 id: 3;
+		                 message: '';
+		                 created_at: createdAt + 1 minutes;
+		                 committed_date: createdAt + 1 minutes;
+		                 repository: project1 repository;
+		                 deletions: 5.
+
+	"those commits will be added to the MR with the mock importer"
+	glhImporter commits: {
+			commit1.
+			commitMerged.
+			commitMerged2 }.
+
+	jiraImporter := JiraImporterMock new.
+	jiraIssue := JPIssue new
+		             id: 'TI-202';
+		             "TI-202 does not exist it is normal here"key: 'TI-202';
+		             timeEstimate: 25 hours;
+		             yourself.
+	jiraIssue2 := JPIssue new
+		              id: 'Hello world';
+		              key: 'Hello world';
+		              timeEstimate: 25 hours;
+		              yourself.
+	jiraImporter issues: {
+			jiraIssue.
+			jiraIssue2 }.
+
+	jiraLinked := CommitLinkedToJiraProjectMetric new
+		              project: project1;
+		              glhImporter: glhImporter;
+		              jiraImporter: jiraImporter;
+		              setPeriodSince: since until: until;
+		              over: Week.
+
+	result := jiraLinked calculate.
+
+	self assert: result equals: 0
+]

--- a/src/GitLabHealth-Model-Analysis-Tests/MergeRequestLinkedToJiraProjectMetricTest.class.st
+++ b/src/GitLabHealth-Model-Analysis-Tests/MergeRequestLinkedToJiraProjectMetricTest.class.st
@@ -1,0 +1,312 @@
+"
+A MergeRequestLinkedToJiraProjectMetricTest is a test class for testing the behavior of MergeRequestLinkedToJiraProjectMetric
+"
+Class {
+	#name : #MergeRequestLinkedToJiraProjectMetricTest,
+	#superclass : #ProjectMetricTest,
+	#category : #'GitLabHealth-Model-Analysis-Tests'
+}
+
+{ #category : #tests }
+MergeRequestLinkedToJiraProjectMetricTest >> testCalculate [
+
+	| result glhImporter jiraImporter jiraMRDifference jiraIssue commitMerged commit1|
+	glhImporter := GLPHImporterMock new.
+	
+	
+	commit1 := (GLHCommit new
+			 id: 1;
+			 created_at: createdAt;
+			 committed_date: createdAt;
+			 repository: project1 repository;
+			 deletions: 5).
+			
+	commitMerged := (GLHCommit new
+			 id: 2;
+			 created_at: createdAt + 1 minutes ;
+			 committed_date: createdAt + 1 minutes;
+			 repository: project1 repository;
+			 deletions: 5).
+	
+	glhImporter mergeRequests: { (GLHMergeRequest new
+			 project: project1;
+			 created_at: createdAt;
+			 merged_at: createdAt + 24 hours;
+			 state: #merged;
+			 mergedCommit: commitMerged; 
+			 title: '[TI-205] feat do something') }.
+
+	"those commits will be added to the MR with the mock importer"
+	glhImporter commits: { commit1 }.
+
+
+
+	jiraImporter := JiraImporterMock new.
+	jiraIssue := JPIssue new
+		             id: 'TI-205';
+		             key: 'TI-205';
+		             timeEstimate: 25 hours;
+		             yourself.
+	jiraImporter issues: { jiraIssue }.
+
+
+
+	jiraMRDifference := MergeRequestLinkedToJiraProjectMetric new
+		                    project: project1;
+		                    glhImporter: glhImporter;
+		                    jiraImporter: jiraImporter;
+		                    setPeriodSince: since until: until;
+		                    over: Week.
+
+
+	result := jiraMRDifference calculate.
+
+
+	self assert: result equals: 1
+]
+
+{ #category : #tests }
+MergeRequestLinkedToJiraProjectMetricTest >> testCalculateSeveral [
+
+	| result glhImporter jiraImporter jiraIssue commitMerged commit1 jiraIssue2 commitMerged2 jiraLinked |
+	glhImporter := GLPHImporterMock new.
+
+	commit1 := GLHCommit new
+		           id: 1;
+		           created_at: createdAt;
+		           committed_date: createdAt;
+		           repository: project1 repository;
+		           deletions: 5.
+
+	commitMerged := GLHCommit new
+		                id: 2;
+		                created_at: createdAt + 1 minutes;
+		                committed_date: createdAt + 1 minutes;
+		                repository: project1 repository;
+		                deletions: 5.
+
+	commitMerged2 := GLHCommit new
+		                 id: 3;
+		                 created_at: createdAt + 1 minutes;
+		                 committed_date: createdAt + 1 minutes;
+		                 repository: project1 repository;
+		                 deletions: 5.
+
+	glhImporter mergeRequests: {
+			(GLHMergeRequest new
+				 project: project1;
+				 created_at: createdAt;
+				 merged_at: createdAt + 24 hours;
+				 state: #merged;
+				 mergedCommit: commitMerged;
+				 title: '[TI-205] feat do something').
+			(GLHMergeRequest new
+				 project: project1;
+				 created_at: createdAt;
+				 merged_at: createdAt + 24 hours;
+				 state: #merged;
+				 mergedCommit: commitMerged2;
+				 title: '[TI-206] feat do something') }.
+
+	"those commits will be added to the MR with the mock importer"
+	glhImporter commits: {
+			commit1.
+			commitMerged.
+			commitMerged2 }.
+
+
+
+	jiraImporter := JiraImporterMock new.
+	jiraIssue := JPIssue new
+		             id: 'TI-205';
+		             key: 'TI-205';
+		             timeEstimate: 25 hours;
+		             yourself.
+	jiraIssue2 := JPIssue new
+		              id: 'TI-206';
+		              key: 'TI-206';
+		              timeEstimate: 25 hours;
+		              yourself.
+	jiraImporter issues: {
+			jiraIssue.
+			jiraIssue2 }.
+
+
+
+	jiraLinked := MergeRequestLinkedToJiraProjectMetric new
+		              project: project1;
+		              glhImporter: glhImporter;
+		              jiraImporter: jiraImporter;
+		              setPeriodSince: since until: until;
+		              over: Week.
+
+
+	result := jiraLinked calculate.
+
+
+	self assert: result equals: 2
+]
+
+{ #category : #tests }
+MergeRequestLinkedToJiraProjectMetricTest >> testCalculateSeveralWithOneError [
+
+	| result glhImporter jiraImporter jiraIssue commitMerged commit1 jiraIssue2 commitMerged2 jiraLinked |
+	glhImporter := GLPHImporterMock new.
+
+	commit1 := GLHCommit new
+		           id: 1;
+		           created_at: createdAt;
+		           committed_date: createdAt;
+		           repository: project1 repository;
+		           deletions: 5.
+
+	commitMerged := GLHCommit new
+		                id: 2;
+		                created_at: createdAt + 1 minutes;
+		                committed_date: createdAt + 1 minutes;
+		                repository: project1 repository;
+		                deletions: 5.
+
+	commitMerged2 := GLHCommit new
+		                 id: 3;
+		                 created_at: createdAt + 1 minutes;
+		                 committed_date: createdAt + 1 minutes;
+		                 repository: project1 repository;
+		                 deletions: 5.
+
+	glhImporter mergeRequests: {
+			(GLHMergeRequest new
+				 project: project1;
+				 created_at: createdAt;
+				 merged_at: createdAt + 24 hours;
+				 state: #merged;
+				 mergedCommit: commitMerged;
+				 title: '[TI-205] feat do something').
+			(GLHMergeRequest new
+				 project: project1;
+				 created_at: createdAt;
+				 merged_at: createdAt + 24 hours;
+				 state: #merged;
+				 mergedCommit: commitMerged2;
+				 title: '[TI-206] feat do something') }.
+
+	"those commits will be added to the MR with the mock importer"
+	glhImporter commits: {
+			commit1.
+			commitMerged.
+			commitMerged2 }.
+
+
+
+	jiraImporter := JiraImporterMock new.
+	jiraIssue := JPIssue new
+		             id: 'TI-205';
+		             key: 'TI-205';
+		             timeEstimate: 25 hours;
+		             yourself.
+	jiraIssue2 := JPIssue new
+		              id: 'Hello world';
+		              key: 'Hello world';
+		              timeEstimate: 25 hours;
+		              yourself.
+	jiraImporter issues: {
+			jiraIssue.
+			jiraIssue2 }.
+
+
+
+	jiraLinked := MergeRequestLinkedToJiraProjectMetric new
+		              project: project1;
+		              glhImporter: glhImporter;
+		              jiraImporter: jiraImporter;
+		              setPeriodSince: since until: until;
+		              over: Week.
+
+
+	result := jiraLinked calculate.
+
+
+	self assert: result equals: 1
+]
+
+{ #category : #tests }
+MergeRequestLinkedToJiraProjectMetricTest >> testCalculateSeveralWithOnlyError [
+
+	| result glhImporter jiraImporter jiraIssue commitMerged commit1 jiraIssue2 commitMerged2 jiraLinked |
+	glhImporter := GLPHImporterMock new.
+
+	commit1 := GLHCommit new
+		           id: 1;
+		           created_at: createdAt;
+		           committed_date: createdAt;
+		           repository: project1 repository;
+		           deletions: 5.
+
+	commitMerged := GLHCommit new
+		                id: 2;
+		                created_at: createdAt + 1 minutes;
+		                committed_date: createdAt + 1 minutes;
+		                repository: project1 repository;
+		                deletions: 5.
+
+	commitMerged2 := GLHCommit new
+		                 id: 3;
+		                 created_at: createdAt + 1 minutes;
+		                 committed_date: createdAt + 1 minutes;
+		                 repository: project1 repository;
+		                 deletions: 5.
+
+	glhImporter mergeRequests: {
+			(GLHMergeRequest new
+				 project: project1;
+				 created_at: createdAt;
+				 merged_at: createdAt + 24 hours;
+				 state: #merged;
+				 mergedCommit: commitMerged;
+				 title: '[TI-205] feat do something').
+			(GLHMergeRequest new
+				 project: project1;
+				 created_at: createdAt;
+				 merged_at: createdAt + 24 hours;
+				 state: #merged;
+				 mergedCommit: commitMerged2;
+				 title: '[TI-206] feat do something') }.
+
+	"those commits will be added to the MR with the mock importer"
+	glhImporter commits: {
+			commit1.
+			commitMerged.
+			commitMerged2 }.
+
+
+
+	jiraImporter := JiraImporterMock new.
+	jiraIssue := JPIssue new
+		             id: 'TI-202'; "TI-202 does not exist it is normal here"
+		             key: 'TI-202';
+		             timeEstimate: 25 hours;
+		             yourself.
+	jiraIssue2 := JPIssue new
+		              id: 'Hello world';
+		              key: 'Hello world';
+		              timeEstimate: 25 hours;
+		              yourself.
+	jiraImporter issues: {
+			jiraIssue.
+			jiraIssue2 }.
+
+
+
+	jiraLinked := MergeRequestLinkedToJiraProjectMetric new
+		              project: project1;
+		              glhImporter: glhImporter;
+		              jiraImporter: jiraImporter;
+		              setPeriodSince: since until: until;
+		              over: Week.
+
+
+	result := jiraLinked calculate.
+
+
+	self assert: result equals: 0
+]

--- a/src/GitLabHealth-Model-Analysis/CommitLinkedToJiraProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/CommitLinkedToJiraProjectMetric.class.st
@@ -1,0 +1,63 @@
+Class {
+	#name : #CommitLinkedToJiraProjectMetric,
+	#superclass : #ProjectMetric,
+	#instVars : [
+		'issues'
+	],
+	#category : #'GitLabHealth-Model-Analysis'
+}
+
+{ #category : #calculating }
+CommitLinkedToJiraProjectMetric >> calculate [
+
+	| groupedByDate dateOver |
+	projectCommits ifNil: [ self load ].
+	projectCommits := projectCommits reject: [ :commit |
+		                  commit jiraIssue isNil ].
+	projectCommits ifEmpty: [ ^ 0 ].
+
+	groupedByDate := self setupGroupedDate.
+	projectCommits do: [ :mr |
+		dateOver := self transformDate: mr created_at to: over.
+
+		groupedByDate
+			at: dateOver printString
+			ifPresent: [ :value | value add: mr ] ].
+
+	groupedByDate := groupedByDate collect: [ :group |
+		                 | average |
+		                 average := group
+			                            ifEmpty: [ 0 ]
+			                            ifNotEmpty: [ group size ].
+		                 average ].
+
+	^ groupedByDate average asFloat
+]
+
+{ #category : #accessing }
+CommitLinkedToJiraProjectMetric >> description [
+
+	^ 'number of commits linked to a jira ticket'
+]
+
+{ #category : #loading }
+CommitLinkedToJiraProjectMetric >> load [
+
+	projectCommits := self
+		                  loadCommitsSince: (period at: #since)
+		                  until: (period at: #until).
+	self loadCommitRequestIssues: projectCommits
+]
+
+{ #category : #issue }
+CommitLinkedToJiraProjectMetric >> loadCommitRequestIssues: aCommitCollection [
+
+	aCommitCollection do: [ :commit |
+		| id |
+		id := GPJCConnector new jiraKeyFromCommitMessage: commit message.
+		jiraImporter importIssue: id.
+		GPJCConnector new
+			gpModel: glhImporter glhModel;
+			jiraModel: jiraImporter model;
+			connect ]
+]

--- a/src/GitLabHealth-Model-Analysis/MergeRequestLinkedToJiraProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/MergeRequestLinkedToJiraProjectMetric.class.st
@@ -1,0 +1,69 @@
+Class {
+	#name : #MergeRequestLinkedToJiraProjectMetric,
+	#superclass : #ProjectMetric,
+	#instVars : [
+		'issues'
+	],
+	#category : #'GitLabHealth-Model-Analysis'
+}
+
+{ #category : #calculating }
+MergeRequestLinkedToJiraProjectMetric >> calculate [
+
+	| groupedByDate dateOver |
+	projectMergeRequests ifNil: [ self load ].
+	projectMergeRequests := projectMergeRequests reject: [ :mr |
+		                        mr jiraIssue isNil ].
+	projectMergeRequests ifEmpty: [ ^ 0 ].
+
+	groupedByDate := self setupGroupedDate.
+	projectMergeRequests do: [ :mr |
+		dateOver := self transformDate: mr created_at to: over.
+
+		groupedByDate
+			at: dateOver printString
+			ifPresent: [ :value | value add: mr ] ].
+
+	groupedByDate := groupedByDate collect: [ :group |
+		                 | average |
+		                 average := group
+			                            ifEmpty: [ 0 ]
+			                            ifNotEmpty: [ group size ].
+		                 average ].
+
+	^ groupedByDate average asFloat
+]
+
+{ #category : #accessing }
+MergeRequestLinkedToJiraProjectMetric >> description [
+
+	^ 'number of merged merge request linked to a jira ticket'
+]
+
+{ #category : #loading }
+MergeRequestLinkedToJiraProjectMetric >> load [
+
+	projectMergeRequests := self
+		                        loadProjectCompleteMergeRequestsSince:
+		                        (period at: #since)
+		                        until: (period at: #until).
+
+	projectMergeRequests := projectMergeRequests select: [ :mergeRequest |
+		                        mergeRequest state = #merged and: [
+			                        mergeRequest merged_at isNotNil ] ].
+
+	self loadMergeRequestIssues: projectMergeRequests
+]
+
+{ #category : #issue }
+MergeRequestLinkedToJiraProjectMetric >> loadMergeRequestIssues: aMergeRequestCollection [
+
+	aMergeRequestCollection do: [ :mr |
+		| id |
+		id := GPJCConnector new jiraKeyFromCommitMessage: mr title.
+		jiraImporter importIssue: id.
+		GPJCConnector new
+			gpModel: glhImporter glhModel;
+			jiraModel: jiraImporter model;
+			connect ]
+]


### PR DESCRIPTION
Add metric to calculate the number of PR and commits links to a Jira ticket