### PR TITLE
group entities by id instead of project name

### DIFF
--- a/src/GitLabHealth-Model-Analysis-Tests/GitMetricExporterTest.class.st
+++ b/src/GitLabHealth-Model-Analysis-Tests/GitMetricExporterTest.class.st
@@ -10,7 +10,7 @@ Class {
 	#category : #'GitLabHealth-Model-Analysis-Tests'
 }
 
-{ #category : #tests }
+{ #category : #running }
 GitMetricExporterTest >> setUp [
 
 	| period |
@@ -35,7 +35,7 @@ GitMetricExporterTest >> setUp [
 				 yourself) }
 ]
 
-{ #category : #tests }
+{ #category : #running }
 GitMetricExporterTest >> tearDown [
 	GitMetricExporter recoverFromGHMutation.
 	super tearDown.

--- a/src/GitLabHealth-Model-Analysis-Tests/GitMetricExporterTest.class.st
+++ b/src/GitLabHealth-Model-Analysis-Tests/GitMetricExporterTest.class.st
@@ -1,0 +1,56 @@
+"
+A GitMetricExporterTest is a test class for testing the behavior of GitMetricExporter
+"
+Class {
+	#name : #GitMetricExporterTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'gme'
+	],
+	#category : #'GitLabHealth-Model-Analysis-Tests'
+}
+
+{ #category : #tests }
+GitMetricExporterTest >> setUp [
+
+	| period |
+	super setUp.
+	gme := GitMetricExporter new.
+	period := {
+		          (#since -> '2024-09-04' asDate).
+		          (#until -> '2024-09-05' asDate) } asDictionary.
+	gme analyses: {
+			(ProjectAnalysisReport new
+				 projectID: 12;
+				 projectName: 'A Nice Project';
+				 over: Week;
+				 period: period;
+				 yourself).
+			"same name in purpose"
+			(ProjectAnalysisReport new
+				 projectID: 13;
+				 projectName: 'A Nice Project';
+				 over: Week;
+				 period: period;
+				 yourself) }
+]
+
+{ #category : #tests }
+GitMetricExporterTest >> tearDown [
+	GitMetricExporter recoverFromGHMutation.
+	super tearDown.
+]
+
+{ #category : #tests }
+GitMetricExporterTest >> testExportProjectAnalysesInCSV [
+
+	| memoryFile |
+	memoryFile := (FileSystem memory / 'test.csv') asFileReference.
+	(gme stub constructFilePathFor: Any andEntities: Any) willReturn:
+		memoryFile.
+	gme exportProjectAnalysesInCSV.
+	"Include project ID 12"
+	self assert: (memoryFile contents includesSubstring: '"12"').
+	"Include project ID 13"
+	self assert: (memoryFile contents includesSubstring: '"13"')
+]

--- a/src/GitLabHealth-Model-Analysis/GitMetricExporter.class.st
+++ b/src/GitLabHealth-Model-Analysis/GitMetricExporter.class.st
@@ -111,6 +111,18 @@ GitMetricExporter >> addEntitiesFromUserNamesAndProjects: usersWithProjects [
 	^ self 
 ]
 
+{ #category : #accessing }
+GitMetricExporter >> analyses [
+
+	^ analyses
+]
+
+{ #category : #accessing }
+GitMetricExporter >> analyses: anObject [
+
+	^ analyses := anObject
+]
+
 { #category : #utilities }
 GitMetricExporter >> constructFilePathFor: runningOver andEntities: entitiesName [
 
@@ -264,7 +276,6 @@ GitMetricExporter >> exportProjectAnalysesInCSV [
 				exportBrowserModel
 					addColumnForQuery: association value
 					withName: association key ] ].
-
 		file := self constructFilePathFor: groupOver andEntities: 'projects'.
 		file writeStreamDo: [ :aStream |
 			exportBrowserModel writeCSVOn: aStream ] ]

--- a/src/GitLabHealth-Model-Analysis/GitMetricExporter.class.st
+++ b/src/GitLabHealth-Model-Analysis/GitMetricExporter.class.st
@@ -237,7 +237,7 @@ GitMetricExporter >> exportProjectAnalysesInCSV [
 		groupOver := groupAssociation key.
 
 
-		groupByName := group groupedBy: #projectName.
+		groupByName := group groupedBy: #projectID.
 		exportBrowserModel entitiesList: groupByName.
 
 		exportBrowserModel removeColumnForQueryNamed: #Type.


### PR DESCRIPTION
If we have multiple projects with the same name, it groups them together leading to issue in data.
So group project by unique id should be better