### PR TITLE
Fix importer Bitbucket of the model

### DIFF
--- a/src/BitBucketHealth-Model-Importer-Tests/BitBucketModelImporterTest.class.st
+++ b/src/BitBucketHealth-Model-Importer-Tests/BitBucketModelImporterTest.class.st
@@ -456,6 +456,43 @@ BitBucketModelImporterTest >> testImportMergeRequestsSinceUntil [
 ]
 
 { #category : #tests }
+BitBucketModelImporterTest >> testImportMergeRequestsSinceUntilAttachedToGoodProject [
+
+	| bitBucketApi glphModel bitBucketImporter group repo project mergeRequests |
+	"Given"
+	bitBucketApi := BitBucketApiMock new.
+
+	glphModel := GLHModel new name: 'test'.
+
+	bitBucketImporter := BitBucketModelImporter new
+		                     repoApi: bitBucketApi;
+		                     glhModel: glphModel.
+
+	group := GLHGroup new id: 1.
+	repo := GLHRepository new.
+	project := GLHProject new
+		           group: group;
+		           id: 'repo-slug';
+		           repository: repo.
+	glphModel add: project.
+
+	"When"
+	mergeRequests := bitBucketImporter
+		                 importMergeRequests: project
+		                 since: '09-23-2024'
+		                 until: '09-25-2024'.
+
+	"Then"
+	self
+		assert:
+		(bitBucketImporter glhModel allWithType: GLHMergeRequest) size
+		equals: 1.
+
+	self assert: project mergeRequests size equals: 1.
+
+]
+
+{ #category : #tests }
 BitBucketModelImporterTest >> testImportMergeRequestsSinceUntilClosedMR [
 
 	| bitBucketApi glphModel bitBucketImporter group repo project mergeRequests mergeRequest |

--- a/src/BitBucketHealth-Model-Importer-Tests/BitBucketModelImporterTest.class.st
+++ b/src/BitBucketHealth-Model-Importer-Tests/BitBucketModelImporterTest.class.st
@@ -43,7 +43,7 @@ BitBucketModelImporterTest >> testConvertBitBucketDiffToGitDiff [
 	glhModel := GLHModel new name: 'test'.
 	
 	bitBucketImporter := BitBucketModelImporter new
-		                     bitBucketApi: bitBucketApi;
+		                     repoApi: bitBucketApi;
 		                     glhModel: glhModel.
 	
 	diffs := bitBucketApi diffs.
@@ -74,7 +74,7 @@ BitBucketModelImporterTest >> testConvertBitBucketDiffToGitDiffNoHunks [
 	glhModel := GLHModel new name: 'test'.
 	
 	bitBucketImporter := BitBucketModelImporter new
-		                     bitBucketApi: bitBucketApi;
+		                     repoApi: bitBucketApi;
 		                     glhModel: glhModel.
 	
 	diffs := bitBucketApi diffsNohunks.

--- a/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
+++ b/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
@@ -526,7 +526,7 @@ BitBucketModelImporter >> parsePullRequestIntoGLPHEMergeRequest: pullRequestDict
 	repository := toRef at: #repository.
 	project := (self glhModel allWithType: GLHProject)
 		           detect: [ :glhProject |
-		           glhProject id = (repository at: #id) ]
+		           glhProject id = (repository at: #slug) ]
 		           ifFound: [ :glhProject | glhProject ]
 		           ifNone: [
 			           project := self parseRepoIntoGLHProject: repository.


### PR DESCRIPTION
- Fix deprecated method call in test
- Use of slug as id in the gph model. This is to avoid conflict when analyzing data... maybe it should be done differently in the future