### PR TITLE
Bitbucket import projects

### DIFF
--- a/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
+++ b/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
@@ -187,6 +187,25 @@ BitBucketModelImporter >> importAndLoadLatestsCommitsOfProject: aGLHProject [
 ]
 
 { #category : #'import - commits' }
+BitBucketModelImporter >> importCommit: aCommitID ofProject: aGLHProject [
+
+	| result parsedResult |
+	(self glhModel allWithType: GLHCommit) asOrderedCollection
+		detect: [ :commit | commit id = aCommitID ]
+		ifFound: [ :commit | ^ commit ].
+	result := self repoApi commits
+		          get: aCommitID
+		          inRepository: aGLHProject id
+		          ofProject: aGLHProject group id.
+	parsedResult := self
+		                parseCommitIntoGLHCommit: result
+		                ofProject: aGLHProject.
+
+	self glhModel addAll: { parsedResult } unless: self blockOnIdEquality.
+	^ parsedResult
+]
+
+{ #category : #'import - commits' }
 BitBucketModelImporter >> importCommitsOfProject: aGLHProject since: since until: until [
 
 	| commits |

--- a/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
+++ b/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
@@ -554,7 +554,7 @@ BitBucketModelImporter >> parsePullRequestIntoGLPHEMergeRequest: pullRequestDict
 		                     target_project_id:
 			                     ((toRef at: #repository) at: #id);
 		                     source_branch: (fromRef at: #id);
-		                     target_project_id:
+		                     source_project_id:
 			                     ((fromRef at: #repository) at: #id);
 		                     updated_at: (DateAndTime fromUnixTime:
 					                      (pullRequestDictionary at: #updatedDate)

--- a/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
+++ b/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
@@ -426,6 +426,7 @@ BitBucketModelImporter >> importProject: aProjectID ofGroup: aGroup [
 		                 get: aProjectID
 		                 ofProject: aGroup id.
 	project := self parseRepoIntoGLHProject: repoOfProject.
+	self glhModel add: project.
 	^ project
 ]
 

--- a/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
+++ b/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
@@ -334,6 +334,34 @@ BitBucketModelImporter >> importMergeRequestCommits: mergeRequest [
 	^ commits
 ]
 
+{ #category : #'import - merge request' }
+BitBucketModelImporter >> importMergeRequestMergeCommits: aGLHMergeRequest [
+
+	aGLHMergeRequest mergedCommit ifNotNil: [
+		^ { aGLHMergeRequest mergedCommit } ].
+
+	aGLHMergeRequest project repository commits
+		detect: [ :c |
+		c parent_ids includes: aGLHMergeRequest commits last id ]
+		ifFound: [ :found |
+			aGLHMergeRequest mergedCommit: found.
+			aGLHMergeRequest merge_commit_sha: found id.
+			^ { found } ].
+
+	self
+		importCommitsOfProject: aGLHMergeRequest project
+		since: aGLHMergeRequest created_at
+		until: aGLHMergeRequest merged_at.
+	self chainsCommitsFrom: aGLHMergeRequest project repository commits.
+	aGLHMergeRequest project repository commits
+		detect: [ :c |
+		c parent_ids includes: aGLHMergeRequest commits last id ]
+		ifFound: [ :found |
+			aGLHMergeRequest mergedCommit: found.
+			aGLHMergeRequest merge_commit_sha: found id.
+			^ { found } ]
+]
+
 { #category : #'import - merge-requests' }
 BitBucketModelImporter >> importMergeRequests: aGLHProject since: fromDate until: toDate [
 

--- a/src/GitLabHealth-Model-Analysis/CodeAdditionByMergeRequestProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/CodeAdditionByMergeRequestProjectMetric.class.st
@@ -50,9 +50,11 @@ CodeAdditionByMergeRequestProjectMetric >> load [
 
 	projectMergeRequests do: [ :mr |
 		glhImporter importMergeRequestMergeCommits: mr ].
-	
-	self flag: 'Should not happens, but sometimes with branch renaming of bitbucket it happens'.
+
+	self flag:
+		'Should not happens, but sometimes with branch renaming of bitbucket it happens'.
 	projectMergeRequests := projectMergeRequests select: [ :mr |
 		                        mr mergedCommit isNotNil or: [
-			                        mr squashCommit isNotNil ] ]
+			                        mr squashCommit isNotNil or: [
+				                        mr mergeRequestCommit isNotNil ] ] ]
 ]

--- a/src/GitLabHealth-Model-Analysis/CodeAdditionByMergeRequestProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/CodeAdditionByMergeRequestProjectMetric.class.st
@@ -40,12 +40,18 @@ CodeAdditionByMergeRequestProjectMetric >> description [
 CodeAdditionByMergeRequestProjectMetric >> load [
 
 	projectMergeRequests := self
-		                  loadProjectCompleteMergeRequestsSince: (period at: #since)
-		                  until: (period at: #until).
-		
-	projectMergeRequests := projectMergeRequests select: [ :mr |
-		                        mr state = #merged ]. 
-		
-	projectMergeRequests do: [:mr | glhImporter importMergeRequestMergeCommits: mr].
+		                        loadProjectCompleteMergeRequestsSince:
+		                        (period at: #since)
+		                        until: (period at: #until).
 
+	projectMergeRequests := projectMergeRequests select: [ :mr |
+		                        mr state = #merged ].
+
+	projectMergeRequests do: [ :mr |
+		glhImporter importMergeRequestMergeCommits: mr ].
+	
+	self flag: 'Should not happens, but sometimes with branch renaming of bitbucket it happens'.
+	projectMergeRequests := projectMergeRequests select: [ :mr |
+		                        mr mergedCommit isNotNil or: [
+			                        mr squashCommit isNotNil ] ]
 ]

--- a/src/GitLabHealth-Model-Analysis/CodeDeletionByMergeRequestProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/CodeDeletionByMergeRequestProjectMetric.class.st
@@ -40,6 +40,19 @@ CodeDeletionByMergeRequestProjectMetric >> description [
 CodeDeletionByMergeRequestProjectMetric >> load [
 
 	projectMergeRequests := self
-		                  loadProjectCompleteMergeRequestsSince: (period at: #since)
-		                  until: (period at: #until)
+		                        loadProjectCompleteMergeRequestsSince:
+		                        (period at: #since)
+		                        until: (period at: #until).
+
+	projectMergeRequests := projectMergeRequests select: [ :mr |
+		                        mr state = #merged ].
+
+	projectMergeRequests do: [ :mr |
+		glhImporter importMergeRequestMergeCommits: mr ].
+
+	self flag:
+		'Should not happens, but sometimes with branch renaming of bitbucket it happens'.
+	projectMergeRequests := projectMergeRequests select: [ :mr |
+		                        mr mergedCommit isNotNil or: [
+			                        mr squashCommit isNotNil ] ]
 ]

--- a/src/GitLabHealth-Model-Analysis/CodeDeletionByMergeRequestProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/CodeDeletionByMergeRequestProjectMetric.class.st
@@ -55,5 +55,6 @@ CodeDeletionByMergeRequestProjectMetric >> load [
 		'Should not happens, but sometimes with branch renaming of bitbucket it happens'.
 	projectMergeRequests := projectMergeRequests select: [ :mr |
 		                        mr mergedCommit isNotNil or: [
-			                        mr squashCommit isNotNil ] ]
+			                        mr squashCommit isNotNil or: [
+				                        mr mergeRequestCommit isNotNil ] ] ]
 ]


### PR DESCRIPTION
- add missing method to import correctly projects (with their linked commits and MR)

> There is an issue with branch in bitbucket that has been rename. For this case, you ignore the MR in thus branches (MR without recognized merged commit)