### PR TITLE
fix merged-commit-stat-bitbucket

### DIFF
--- a/src/BitBucketHealth-Model-Importer-Tests/BitBucketModelImporterTest.class.st
+++ b/src/BitBucketHealth-Model-Importer-Tests/BitBucketModelImporterTest.class.st
@@ -418,6 +418,84 @@ BitBucketModelImporterTest >> testImportMergeRequestCommits [
 ]
 
 { #category : #tests }
+BitBucketModelImporterTest >> testImportMergeRequestStats [
+
+	| bitBucketApi glphModel bitBucketImporter mergeRequest commit |
+	"Given"
+	bitBucketApi := BitBucketApiMock new.
+	glphModel := GLHModel new name: 'test'.
+	bitBucketImporter := BitBucketModelImporter new
+		                     repoApi: bitBucketApi;
+		                     glhModel: glphModel.
+	mergeRequest := bitBucketImporter
+		                parsePullRequestIntoGLPHEMergeRequest:
+		                bitBucketApi mergedMergeRequest.
+	commit := GLHCommit new.
+	glphModel add: commit.
+	mergeRequest mergedCommit: commit.
+
+
+	"When"
+	bitBucketImporter importMergeRequestStats: mergeRequest.
+
+	"Then"
+	self deny: mergeRequest mergedCommit equals: nil.
+	self assert: mergeRequest mergedCommit additions equals: 1.
+	self assert: mergeRequest mergedCommit deletions equals: 1
+]
+
+{ #category : #tests }
+BitBucketModelImporterTest >> testImportMergeRequestStatsAlreadyComputed [
+
+	| bitBucketApi glphModel bitBucketImporter mergeRequest commit |
+	"Given"
+	bitBucketApi := BitBucketApiMock new.
+	glphModel := GLHModel new name: 'test'.
+	bitBucketImporter := BitBucketModelImporter new
+		                     repoApi: bitBucketApi;
+		                     glhModel: glphModel.
+	mergeRequest := bitBucketImporter
+		                parsePullRequestIntoGLPHEMergeRequest:
+		                bitBucketApi mergedMergeRequest.
+	commit := GLHCommit new.
+	glphModel add: commit.
+	commit additions: 42.
+	commit deletions: 24.
+	mergeRequest mergedCommit: commit.
+
+
+	"When"
+	bitBucketImporter importMergeRequestStats: mergeRequest.
+
+	"Then"
+	self deny: mergeRequest mergedCommit equals: nil.
+	self assert: mergeRequest mergedCommit additions equals: 42.
+	self assert: mergeRequest mergedCommit deletions equals: 24
+]
+
+{ #category : #tests }
+BitBucketModelImporterTest >> testImportMergeRequestStatsNoMergedCommit [
+
+	| bitBucketApi glphModel bitBucketImporter mergeRequest |
+	"Given"
+	bitBucketApi := BitBucketApiMock new.
+	glphModel := GLHModel new name: 'test'.
+	bitBucketImporter := BitBucketModelImporter new
+		                     repoApi: bitBucketApi;
+		                     glhModel: glphModel.
+	mergeRequest := bitBucketImporter
+		                parsePullRequestIntoGLPHEMergeRequest:
+		                bitBucketApi mergedMergeRequest.
+
+
+	"When"
+	bitBucketImporter importMergeRequestStats: mergeRequest.
+
+	"Then"
+	self assert: mergeRequest mergedCommit equals: nil
+]
+
+{ #category : #tests }
 BitBucketModelImporterTest >> testImportMergeRequestsSinceUntil [
 
 	| bitBucketApi glphModel bitBucketImporter group repo project mergeRequests mergeRequest |

--- a/src/BitBucketHealth-Model-Importer-Tests/BitbucketPullRequestsMock.class.st
+++ b/src/BitBucketHealth-Model-Importer-Tests/BitbucketPullRequestsMock.class.st
@@ -21,3 +21,9 @@ BitbucketPullRequestsMock >> commitsOf: pullRequestId inRepository: repositorySl
 
 		^ commitsMock
 ]
+
+{ #category : #'api - get' }
+BitbucketPullRequestsMock >> diffOf: commitId inRepository: repositorySlug ofProject: projectKey [
+
+		^ diffs
+]

--- a/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
+++ b/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
@@ -341,7 +341,10 @@ BitBucketModelImporter >> importGroup: aGroupID [
 BitBucketModelImporter >> importMergeRequestCommits: mergeRequest [
 
 	| commits |
-	commits := self repoApi pullRequests commitsOf: mergeRequest id inRepository: mergeRequest project id ofProject: mergeRequest project group id.
+	commits := self repoApi pullRequests
+		           commitsOf: mergeRequest id
+		           inRepository: mergeRequest project id
+		           ofProject: mergeRequest project group id.
 
 	commits := commits collect: [ :commit |
 		           self
@@ -358,13 +361,13 @@ BitBucketModelImporter >> importMergeRequestMergeCommits: aGLHMergeRequest [
 
 	aGLHMergeRequest mergedCommit ifNotNil: [
 		^ { aGLHMergeRequest mergedCommit } ].
-
 	aGLHMergeRequest project repository commits
 		detect: [ :c |
 		c parent_ids includes: aGLHMergeRequest commits last id ]
 		ifFound: [ :found |
 			aGLHMergeRequest mergedCommit: found.
 			aGLHMergeRequest merge_commit_sha: found id.
+			self importMergeRequestStats: aGLHMergeRequest.
 			^ { found } ].
 
 	self
@@ -378,7 +381,30 @@ BitBucketModelImporter >> importMergeRequestMergeCommits: aGLHMergeRequest [
 		ifFound: [ :found |
 			aGLHMergeRequest mergedCommit: found.
 			aGLHMergeRequest merge_commit_sha: found id.
+			self importMergeRequestStats: aGLHMergeRequest.
 			^ { found } ]
+]
+
+{ #category : #'import - merge request' }
+BitBucketModelImporter >> importMergeRequestStats: aMergeRequest [
+
+	| commitDiffs contribution |
+	"can not recompute diff of mergedcommit if none"
+	aMergeRequest mergedCommit ifNil: [ ^ self ].
+	(aMergeRequest mergedCommit additions isNotNil and: [
+		 aMergeRequest mergedCommit deletions isNotNil ]) ifTrue: [ ^ self ].
+
+	commitDiffs := self repoApi pullRequests
+		               diffOf: aMergeRequest id
+		               inRepository: aMergeRequest project id
+		               ofProject: aMergeRequest project group id.
+
+	contribution := self getContributionFromDiffs:
+		                (commitDiffs at: #diffs).
+
+	^ aMergeRequest mergedCommit
+		  additions: (contribution at: #additions);
+		  deletions: (contribution at: #deletions)
 ]
 
 { #category : #'import - merge-requests' }


### PR DESCRIPTION
- Add a method import merge request stat for BitBucket that recompute additions and deletions for merged commit if needed (because it is a particular kind of commit...)