### PR TITLE
check if computed only 0 (and so need to recompute)

### DIFF
--- a/src/BitBucketHealth-Model-Importer-Tests/BitBucketModelImporterTest.class.st
+++ b/src/BitBucketHealth-Model-Importer-Tests/BitBucketModelImporterTest.class.st
@@ -445,6 +445,35 @@ BitBucketModelImporterTest >> testImportMergeRequestStats [
 ]
 
 { #category : #tests }
+BitBucketModelImporterTest >> testImportMergeRequestStats0Computed [
+
+	| bitBucketApi glphModel bitBucketImporter mergeRequest commit |
+	"Given"
+	bitBucketApi := BitBucketApiMock new.
+	glphModel := GLHModel new name: 'test'.
+	bitBucketImporter := BitBucketModelImporter new
+		                     repoApi: bitBucketApi;
+		                     glhModel: glphModel.
+	mergeRequest := bitBucketImporter
+		                parsePullRequestIntoGLPHEMergeRequest:
+		                bitBucketApi mergedMergeRequest.
+	commit := GLHCommit new.
+	glphModel add: commit.
+	commit additions: 0.
+	commit deletions: 0.
+	mergeRequest mergedCommit: commit.
+
+
+	"When"
+	bitBucketImporter importMergeRequestStats: mergeRequest.
+
+	"Then"
+	self deny: mergeRequest mergedCommit equals: nil.
+	self assert: mergeRequest mergedCommit additions equals: 1.
+	self assert: mergeRequest mergedCommit deletions equals: 1
+]
+
+{ #category : #tests }
 BitBucketModelImporterTest >> testImportMergeRequestStatsAlreadyComputed [
 
 	| bitBucketApi glphModel bitBucketImporter mergeRequest commit |
@@ -470,6 +499,64 @@ BitBucketModelImporterTest >> testImportMergeRequestStatsAlreadyComputed [
 	"Then"
 	self deny: mergeRequest mergedCommit equals: nil.
 	self assert: mergeRequest mergedCommit additions equals: 42.
+	self assert: mergeRequest mergedCommit deletions equals: 24
+]
+
+{ #category : #tests }
+BitBucketModelImporterTest >> testImportMergeRequestStatsAlreadyComputedAdditionsStatOnly [
+
+	| bitBucketApi glphModel bitBucketImporter mergeRequest commit |
+	"Given"
+	bitBucketApi := BitBucketApiMock new.
+	glphModel := GLHModel new name: 'test'.
+	bitBucketImporter := BitBucketModelImporter new
+		                     repoApi: bitBucketApi;
+		                     glhModel: glphModel.
+	mergeRequest := bitBucketImporter
+		                parsePullRequestIntoGLPHEMergeRequest:
+		                bitBucketApi mergedMergeRequest.
+	commit := GLHCommit new.
+	glphModel add: commit.
+	commit additions: 42.
+	commit deletions: 0.
+	mergeRequest mergedCommit: commit.
+
+
+	"When"
+	bitBucketImporter importMergeRequestStats: mergeRequest.
+
+	"Then"
+	self deny: mergeRequest mergedCommit equals: nil.
+	self assert: mergeRequest mergedCommit additions equals: 42.
+	self assert: mergeRequest mergedCommit deletions equals: 0
+]
+
+{ #category : #tests }
+BitBucketModelImporterTest >> testImportMergeRequestStatsAlreadyComputedDeletionsStatOnly [
+
+	| bitBucketApi glphModel bitBucketImporter mergeRequest commit |
+	"Given"
+	bitBucketApi := BitBucketApiMock new.
+	glphModel := GLHModel new name: 'test'.
+	bitBucketImporter := BitBucketModelImporter new
+		                     repoApi: bitBucketApi;
+		                     glhModel: glphModel.
+	mergeRequest := bitBucketImporter
+		                parsePullRequestIntoGLPHEMergeRequest:
+		                bitBucketApi mergedMergeRequest.
+	commit := GLHCommit new.
+	glphModel add: commit.
+	commit additions: 0.
+	commit deletions: 24.
+	mergeRequest mergedCommit: commit.
+
+
+	"When"
+	bitBucketImporter importMergeRequestStats: mergeRequest.
+
+	"Then"
+	self deny: mergeRequest mergedCommit equals: nil.
+	self assert: mergeRequest mergedCommit additions equals: 0.
 	self assert: mergeRequest mergedCommit deletions equals: 24
 ]
 

--- a/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
+++ b/src/BitBucketHealth-Model-Importer/BitBucketModelImporter.class.st
@@ -392,7 +392,10 @@ BitBucketModelImporter >> importMergeRequestStats: aMergeRequest [
 	"can not recompute diff of mergedcommit if none"
 	aMergeRequest mergedCommit ifNil: [ ^ self ].
 	(aMergeRequest mergedCommit additions isNotNil and: [
-		 aMergeRequest mergedCommit deletions isNotNil ]) ifTrue: [ ^ self ].
+		 aMergeRequest mergedCommit deletions isNotNil and: [
+			 aMergeRequest mergedCommit additions ~= 0 or: [
+				 aMergeRequest mergedCommit deletions ~= 0 ] ] ]) ifTrue: [
+		^ self ].
 
 	commitDiffs := self repoApi pullRequests
 		               diffOf: aMergeRequest id


### PR DESCRIPTION
Bitbucket case
- check if additions and deletions of MR commit is 0. If true: recompute (probably miss computation before)