### PR TITLE
 New metric on number of acr created pipeline

### DIFF
--- a/src/GitLabHealth-Model-Analysis-Tests/AverageCreatedNotesInMRTest.class.st
+++ b/src/GitLabHealth-Model-Analysis-Tests/AverageCreatedNotesInMRTest.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #AverageCreatedNotesInMRTest,
+	#superclass : #ProjectMetricTest,
+	#category : #'GitLabHealth-Model-Analysis-Tests'
+}
+
+{ #category : #tests }
+AverageCreatedNotesInMRTest >> testCalculate [
+	| glhImporter result nbNotes notes acrBot |
+	"Given"
+	glhImporter := GLPHImporterMock new.
+	
+	acrBot := GLHUser new id: 2661; username: 'AutoCodeReview'; yourself.
+	
+	notes := glhImporter notes: { 
+			(GLHNote new
+			noteable_iid: 2002; 
+			created_at: createdAt ;
+			 updated_at: updatedAt;
+			 author: (GLHUser new id: 123; yourself);
+			 body: 'n importe quoi').
+			(GLHNote new
+			 created_at: createdAt ;
+			 updated_at: updatedAt;
+			 noteable_iid: 2002;
+			 author: acrBot; 
+			 body: 'The automated review has been completed. No modifications were found based on the current analysis rules.')
+			 }.
+			
+	glhImporter mergeRequests: { (GLHMergeRequest new
+			 created_at: createdAt ;
+			 iid: 2002;
+			 state: 'opened';
+			 project: project;
+			 note: notes notes) }.
+	
+
+	nbNotes := AverageCreatedNotesInMR new
+		                  project: project;
+		                  glhImporter: glhImporter;
+		                  setPeriodSince: since until: until;
+								over: Week.
+	"When"
+	result := nbNotes calculate.
+
+	"Then"
+	self assert: result equals: 2
+]

--- a/src/GitLabHealth-Model-Analysis-Tests/CreatedACRPipelineByProjectTest.class.st
+++ b/src/GitLabHealth-Model-Analysis-Tests/CreatedACRPipelineByProjectTest.class.st
@@ -1,0 +1,48 @@
+Class {
+	#name : #CreatedACRPipelineByProjectTest,
+	#superclass : #ProjectMetricTest,
+	#category : #'GitLabHealth-Model-Analysis-Tests'
+}
+
+{ #category : #tests }
+CreatedACRPipelineByProjectTest >> testCalculate [
+	| glhImporter result nbNotes notes acrBot |
+	"Given"
+	glhImporter := GLPHImporterMock new.
+	
+	acrBot := GLHUser new id: 2661; username: 'AutoCodeReview'; yourself.
+	
+	notes := glhImporter notes: { 
+			(GLHNote new
+			noteable_iid: 2002; 
+			created_at: createdAt ;
+			 updated_at: updatedAt;
+			 author: (GLHUser new id: 123; yourself);
+			 body: 'n importe quoi').
+			(GLHNote new
+			 created_at: createdAt ;
+			 updated_at: updatedAt;
+			 noteable_iid: 2002;
+			 author: acrBot; 
+			 body: 'The automated review has been completed. No modifications were found based on the current analysis rules.')
+			 }.
+			
+	glhImporter mergeRequests: { (GLHMergeRequest new
+			 created_at: createdAt ;
+			 iid: 2002;
+			 state: 'opened';
+			 project: project;
+			 note: notes notes) }.
+	
+
+	nbNotes := CreatedACRPipelineByProject new
+		                  project: project;
+		                  glhImporter: glhImporter;
+		                  setPeriodSince: since until: until;
+								over: Week.
+	"When"
+	result := nbNotes calculate.
+
+	"Then"
+	self assert: result equals: 1
+]

--- a/src/GitLabHealth-Model-Analysis/AverageCreatedNotesInMR.class.st
+++ b/src/GitLabHealth-Model-Analysis/AverageCreatedNotesInMR.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : #AverageCreatedNotesInMR,
+	#superclass : #ProjectMetric,
+	#category : #'GitLabHealth-Model-Analysis'
+}
+
+{ #category : #calculating }
+AverageCreatedNotesInMR >> calculate [  
+    | groupedByDate |  
+
+    projectMergeRequests ifNil: [ self load ].  
+    groupedByDate := self setupGroupedDate.  
+
+    projectMergeRequests do: [ :mr |  
+        mr note do: [ :note |  
+            | dateOver |  
+            dateOver := self transformDate: note created_at to: over.  
+            groupedByDate at: dateOver printString ifPresent: [ :v | v add: note ].  
+        ]  
+    ].  
+    groupedByDate := groupedByDate collect: [ :notesGroup |  
+        notesGroup size.  
+    ].   
+    ^ groupedByDate sum asFloat / projectMergeRequests size.
+]
+
+{ #category : #accessing }
+AverageCreatedNotesInMR >> description [
+
+	^ 'Average number of comments/notes by MR for a project'
+]
+
+{ #category : #loading }
+AverageCreatedNotesInMR >> load [
+	projectMergeRequests := self
+	                      loadMergeRequestsSince:  (period at: #since)
+	                      until:  (period at: #until) .
+	projectMergeRequests do: [ :mr | glhImporter importNotesfromMergeRequest: mr ].
+]

--- a/src/GitLabHealth-Model-Analysis/CreatedACRPipelineByProject.class.st
+++ b/src/GitLabHealth-Model-Analysis/CreatedACRPipelineByProject.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : #CreatedACRPipelineByProject,
+	#superclass : #ProjectMetric,
+	#category : #'GitLabHealth-Model-Analysis'
+}
+
+{ #category : #acr }
+CreatedACRPipelineByProject class >> acrBotId [
+	^2661.
+]
+
+{ #category : #calculating }
+CreatedACRPipelineByProject >> calculate [  
+    | groupedByDate |  
+
+    projectMergeRequests ifNil: [ self load ].  
+    groupedByDate := self setupGroupedDate.  
+
+    projectMergeRequests do: [ :mr |  
+        mr note do: [ :note |  
+            | dateOver |  
+            dateOver := self transformDate: note created_at to: over.  
+            groupedByDate at: dateOver printString ifPresent: [ :v | v add: note ].  
+        ]  
+    ].  
+    groupedByDate := groupedByDate collect: [ :notesGroup |  
+        (notesGroup select: [ :note | (note author isNotNil and: [ note author id = self class acrBotId ]) and: note body = 'The automated review has been completed. No modifications were found based on the current analysis rules.']) size .  
+    ].   
+
+    ^ groupedByDate sum asFloat.
+]
+
+{ #category : #accessing }
+CreatedACRPipelineByProject >> description [
+
+	^ 'Number of ACR pipeline run for a project'
+]
+
+{ #category : #loading }
+CreatedACRPipelineByProject >> load [
+	projectMergeRequests := self
+	                      loadMergeRequestsSince:  (period at: #since)
+	                      until:  (period at: #until) .
+	projectMergeRequests do: [ :mr | glhImporter importNotesfromMergeRequest: mr ].
+]


### PR DESCRIPTION
Original #198 

This is a simple refactor of the CreatedNotesByACRByProjectMetric class. Instead of retrieving all notes created by the ACR bot, it now filters only those with the following body:
The automated review has been completed. No modifications were found based on the current analysis rules.
This specific note is generated every time a pipeline runs. By specifying a time period, the class retrieves the total count of such notes within that range, effectively reflecting the number of ACR runs.

The following commits introduce the AverageCreatedNotesInMR metric. It calculates the average number of notes per merge request by taking the total number of notes from all merge requests and dividing it by the number of merge requests.