### PR TITLE
`importBranchesOf:` is required when performing the full metric analysis

### DIFF
--- a/src/GitProjectHealth-Model-Importer/GitModelImporter.class.st
+++ b/src/GitProjectHealth-Model-Importer/GitModelImporter.class.st
@@ -151,6 +151,12 @@ GitModelImporter >> glhModel: anObject [
 	glhModel := anObject
 ]
 
+{ #category : #'import - repositories' }
+GitModelImporter >> importBranchesOf: aGLHProject [
+
+	^ self subclassResponsibility
+]
+
 { #category : #import }
 GitModelImporter >> importDiffRangesForDiff: aGLHDiff [
 


### PR DESCRIPTION
The `importBranchesOf:` methods is required by the metrics currently implemented