### PR TITLE
should reject user withoutid

### DIFF
--- a/src/GitLabHealth-Model-Analysis/GitMetricExporter.class.st
+++ b/src/GitLabHealth-Model-Analysis/GitMetricExporter.class.st
@@ -562,7 +562,7 @@ GitMetricExporter >> setupAnalysisForUsersWithNames: userNames [
 	glhImporter userCatalogue ifNotNil: [
 		glhImporter userCatalogue scrapeAuthorNamesForUsers: users ].
 
-	users do: [ :user |
+	users select: [ :u | u id isNotNil ] thenDo: [ :user |
 		| projects |
 		projects := glhImporter importContributedProjectsOfUser: user.
 


### PR DESCRIPTION
When user did not fill correctly its id, and we cannot find the user based on our heuristic, do not computer metric and more for this user