### PR TITLE
Make link with Jira faster

### DIFF
--- a/src/GitLabHealth-Model-Analysis/CommitLinkedToJiraProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/CommitLinkedToJiraProjectMetric.class.st
@@ -52,12 +52,14 @@ CommitLinkedToJiraProjectMetric >> load [
 { #category : #issue }
 CommitLinkedToJiraProjectMetric >> loadCommitRequestIssues: aCommitCollection [
 
+	| connector |
+	connector := GPJCConnector new
+		             gpModel: glhImporter glhModel;
+		             jiraModel: jiraImporter model;
+		             yourself.
 	aCommitCollection do: [ :commit |
 		| id |
-		id := GPJCConnector new jiraKeyFromCommitMessage: commit message.
+		id := connector jiraKeyFromCommitMessage: commit message.
 		jiraImporter importIssue: id.
-		GPJCConnector new
-			gpModel: glhImporter glhModel;
-			jiraModel: jiraImporter model;
-			connect ]
+		connector connectCommit: commit ]
 ]

--- a/src/GitLabHealth-Model-Analysis/JiraTimeMRTimeDifferenceProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/JiraTimeMRTimeDifferenceProjectMetric.class.st
@@ -82,11 +82,15 @@ JiraTimeMRTimeDifferenceProjectMetric >> load [
 
 { #category : #issue }
 JiraTimeMRTimeDifferenceProjectMetric >> loadMergeRequestIssues: aMergeRequestCollection [
-	
-	 (aMergeRequestCollection do: [ :mr | 
-		|id|
-		id := GPJCConnector new jiraKeyFromCommitMessage: mr title .
-		jiraImporter importIssue: id.      
-		GPJCConnector new gpModel: glhImporter glhModel; jiraModel: jiraImporter model; connect.
-		 ]).
+
+	| connector |
+	connector := GPJCConnector new
+		             gpModel: glhImporter glhModel;
+		             jiraModel: jiraImporter model;
+		             yourself.
+	aMergeRequestCollection do: [ :mr |
+		| id |
+		id := connector jiraKeyFromCommitMessage: mr title.
+		jiraImporter importIssue: id.
+		connector connectMergeRequest: mr ]
 ]

--- a/src/GitLabHealth-Model-Analysis/MergeRequestLinkedToJiraProjectMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/MergeRequestLinkedToJiraProjectMetric.class.st
@@ -58,12 +58,14 @@ MergeRequestLinkedToJiraProjectMetric >> load [
 { #category : #issue }
 MergeRequestLinkedToJiraProjectMetric >> loadMergeRequestIssues: aMergeRequestCollection [
 
+	| connector |
+	connector := GPJCConnector new
+		             gpModel: glhImporter glhModel;
+		             jiraModel: jiraImporter model;
+		             yourself.
 	aMergeRequestCollection do: [ :mr |
 		| id |
-		id := GPJCConnector new jiraKeyFromCommitMessage: mr title.
+		id := connector jiraKeyFromCommitMessage: mr title.
 		jiraImporter importIssue: id.
-		GPJCConnector new
-			gpModel: glhImporter glhModel;
-			jiraModel: jiraImporter model;
-			connect ]
+		connector connectMergeRequest: mr ]
 ]


### PR DESCRIPTION
Then Jira connect perform a full reconnect between two models.
When computing metrics, we can focus only on the concerned MR and commit.
This should reduce drastically the computation time because we will retrieve the link only once by metric for each element instead of looking through the all model each time.

This should be even better for large computation