### PR TITLE
Optimize jira loading

### DIFF
--- a/src/GitLabHealth-Model-Analysis/CommitsLinkWithTicketMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/CommitsLinkWithTicketMetric.class.st
@@ -42,7 +42,7 @@ CommitsLinkWithTicketMetric >> load [
 	GPJCConnector new
 		gpModel: glhImporter glhModel;
 		jiraModel: jiraImporter model;
-		connect.
+		connectCommits: userCommits.
 
 	^userCommits := userCommits select: [ :commit |
 		  commit jiraIssue isNotNil ]

--- a/src/GitLabHealth-Model-Analysis/UserMetric.class.st
+++ b/src/GitLabHealth-Model-Analysis/UserMetric.class.st
@@ -175,7 +175,7 @@ UserMetric >> loadUserCompleteMergeRequestsWithJiraIssueSince: since until: unti
 	GPJCConnector new
 		gpModel: glhImporter glhModel;
 		jiraModel: jiraImporter model;
-		connect.
+		connectMergeRequests: mergeRequests.
 
 	^ mergeRequests select: [ :mergeRequest |
 		  mergeRequest jiraIssue isNotNil ]
@@ -203,7 +203,7 @@ UserMetric >> loadUserMergeRequestsWithJiraIssueSince: since until: until [
 	GPJCConnector new
 		gpModel: glhImporter glhModel;
 		jiraModel: jiraImporter model;
-		connect.
+		connectMergeRequests: mergeRequests.
 
 	^ mergeRequests select: [ :mergeRequest |
 		  mergeRequest jiraIssue isNotNil ]

--- a/src/GitProject-JiraConnector-Tests/GPJCConnectorTest.class.st
+++ b/src/GitProject-JiraConnector-Tests/GPJCConnectorTest.class.st
@@ -53,6 +53,30 @@ GPJCConnectorTest >> testConnectCommitDoesNotExist [
 	self assert: commit jiraIssue equals: nil
 ]
 
+{ #category : #tests }
+GPJCConnectorTest >> testConnectCommits [
+
+	| issue commit issue2 commit2 |
+	issue := jiraModel newIssue.
+	issue key: 'HELLO-WORLD'.
+
+	commit := gitProject newCommit.
+	commit message: 'I am a commit for [HELLO-WORLD]'.
+
+	issue2 := jiraModel newIssue.
+	issue2 key: 'HELLO-WORLD2'.
+
+	commit2 := gitProject newCommit.
+	commit2 message: 'I am a commit for [HELLO-WORLD2]'.
+
+	connector connectCommits: { commit }.
+	self assert: issue commits anyOne equals: commit.
+	self assert: commit jiraIssue equals: issue.
+
+	self assert: issue2 commits isEmpty.
+	self assert: commit2 jiraIssue equals: nil
+]
+
 { #category : #test }
 GPJCConnectorTest >> testConnectMergeRequest [
 
@@ -81,6 +105,30 @@ GPJCConnectorTest >> testConnectMergeRequestDoesNotExist [
 	connector connect.
 	self assert: issue mergeRequest equals: nil.
 	self assert: mergeRequest jiraIssue equals: nil
+]
+
+{ #category : #tests }
+GPJCConnectorTest >> testConnectMergeRequests [
+
+	| issue mergeRequest issue2 mergeRequest2 |
+	issue := jiraModel newIssue.
+	issue key: 'HELLO-WORLD'.
+
+	mergeRequest := gitProject newMergeRequest.
+	mergeRequest title: 'I am a merge request for [HELLO-WORLD]'.
+	
+	issue2 := jiraModel newIssue.
+	issue2 key: 'HELLO-WORLD2'.
+
+	mergeRequest2 := gitProject newMergeRequest.
+	mergeRequest2 title: 'I am a merge request for [HELLO-WORLD2]'.
+
+	connector connectMergeRequests: { mergeRequest }.
+	self assert: issue mergeRequest equals: mergeRequest.
+	self assert: mergeRequest jiraIssue equals: issue.
+	
+	self assert: issue2 mergeRequest equals: nil.
+	self assert: mergeRequest2 jiraIssue equals: nil
 ]
 
 { #category : #test }

--- a/src/GitProject-JiraConnector/GPJCConnector.class.st
+++ b/src/GitProject-JiraConnector/GPJCConnector.class.st
@@ -24,10 +24,10 @@ Class {
 
 { #category : #accessing }
 GPJCConnector >> connect [
-	(self gpModel allWithType: GLHCommit) do: [ :commit |
-		self connectCommit: commit ].
-	(self gpModel allWithType: GLHMergeRequest) do: [ :mergeRequest |
-		self connectMergeRequest: mergeRequest ]
+	"This is slow, if you wanna connect more specific things please consider doing it using helper methods"
+
+	self connectCommits: (self gpModel allWithType: GLHCommit).
+	self connectMergeRequests: (self gpModel allWithType: GLHMergeRequest)
 ]
 
 { #category : #accessing }
@@ -39,11 +39,23 @@ GPJCConnector >> connectCommit: commit [
 ]
 
 { #category : #accessing }
+GPJCConnector >> connectCommits: commits [
+
+	commits do: [ :commit | self connectCommit: commit ]
+]
+
+{ #category : #accessing }
 GPJCConnector >> connectMergeRequest: mergeRequest [
 
 	(jiraModel allWithType: JPIssue)
 		detect: [ :issue | mergeRequest title includesSubstring: issue key ]
 		ifFound: [ :issue | mergeRequest jiraIssue: issue ]
+]
+
+{ #category : #accessing }
+GPJCConnector >> connectMergeRequests: mergeRequests [
+
+	mergeRequests do: [ :mergeRequest | self connectMergeRequest: mergeRequest ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Loading of model is slow. Sometimes because of the time required to load Jira information (when computing metrics linked to Jira).
This PRs reduce the time required to perform connection between GPH and Jira model when computing _user_ metrics.
It also add helper method