### PR TITLE
Importer gitlab file

### DIFF
--- a/src/GitHubHealth-Model-Importer/GHApi.class.st
+++ b/src/GitHubHealth-Model-Importer/GHApi.class.st
@@ -19,9 +19,17 @@ GHApi class >> isDeprecated [
 { #category : #api }
 GHApi >> actionsRunOfRepo: aRepoName ofOrganization: anOrganizationName [
 
-	^ self client get:
+"	^ self client get:
 		  self baseAPIUrl , '/repos/' , anOrganizationName , '/' , aRepoName
-		  , '/actions/runs'
+		  , '/actions/runs'"
+		
+	self
+		deprecated: 'Use self actions getLatestForRepo:ofOwner: instead of current one'
+		on: '21 august 2025'
+		in:
+		'Pharo-12.0.0+SNAPSHOT.build.1571.sha.cf5fcd22e66957962c97dffc58b0393b7f368147 (64 Bit)'.
+		
+	^ self actions getLatestForRepo: aRepoName  ofOwner: anOrganizationName. 
 ]
 
 { #category : #accessing }

--- a/src/GitHubHealth-Model-Importer/GithubModelImporter.class.st
+++ b/src/GitHubHealth-Model-Importer/GithubModelImporter.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #GithubModelImporter,
 	#superclass : #GitModelImporter,
+	#instVars : [
+		'generalReader'
+	],
 	#category : #'GitHubHealth-Model-Importer'
 }
 
@@ -70,6 +73,25 @@ GithubModelImporter >> completeImportedProject: aGLHProject [
 		| commits |
 		commits := self importCommitsOfProject: aGLHProject.
 		self chainsCommitsFrom: commits ]
+]
+
+{ #category : #'as yet unclassified' }
+GithubModelImporter >> configureReaderForProject: reader [
+
+"	reader mapInstVarsFor: GLHProject. "
+
+	reader for: GLHProject do: [ :mapping | 
+		mapping mapInstVar: #name to: #name.
+		mapping mapInstVar: #description to: #description.
+		mapping mapInstVar: #id to: #id.
+		mapping mapInstVar: #archived to: #archived.
+		mapping mapInstVar: #web_url to: #html_url.
+		mapping mapInstVar: #topics to: #topics ].
+
+	reader
+		for: #ArrayOfProjects 
+		customDo: [ :customMappting |
+		customMappting listOfElementSchema: GLHProject ].
 ]
 
 { #category : #private }
@@ -337,24 +359,35 @@ GithubModelImporter >> importUser: userID [
 ]
 
 { #category : #initialization }
+GithubModelImporter >> initReader [
+
+	generalReader := NeoJSONReader new.
+	self configureReaderForProject: generalReader.
+]
+
+{ #category : #initialization }
 GithubModelImporter >> initialize [
 
 	super initialize.
 	self repoApi: GHApi new.
 	self repoApi output: 'json'.
 	self withCommitDiffs: false.
-	withFiles := false
+	withFiles := false.
+	
+	self initReader
 ]
 
 { #category : #parsing }
 GithubModelImporter >> parseArrayOfProject: arrayOfProjects [
 
 	| reader |
-	reader := NeoJSONReader on: arrayOfProjects readStream.
+" reader := NeoJSONReader on: arrayOfProjects readStream.
+	
 	reader
 		for: #ArrayOfProjects
 		customDo: [ :customMappting | 
 		customMappting listOfElementSchema: GLHProject ].
+	
 	reader for: GLHProject do: [ :mapping | 
 		mapping mapInstVar: #name to: #name.
 		mapping mapInstVar: #description to: #description.
@@ -362,6 +395,11 @@ GithubModelImporter >> parseArrayOfProject: arrayOfProjects [
 		mapping mapInstVar: #archived to: #archived.
 		mapping mapInstVar: #web_url to: #html_url.
 		mapping mapInstVar: #topics to: #topics ].
+	^ reader nextAs: #ArrayOfProjects
+	"
+
+	reader := generalReader on: arrayOfProjects readStream.
+	
 	^ reader nextAs: #ArrayOfProjects
 ]
 
@@ -532,7 +570,7 @@ GithubModelImporter >> parsePipelinesResult: pipelineOverview [
 GithubModelImporter >> parseProjectResult: aResult [
 
 	| reader |
-	reader := NeoJSONReader on: aResult readStream.
+"	reader := NeoJSONReader on: aResult readStream.
 	reader for: GLHProject do: [ :mapping |
 		mapping mapInstVar: #name to: #name.
 		mapping mapInstVar: #description to: #description.
@@ -540,6 +578,10 @@ GithubModelImporter >> parseProjectResult: aResult [
 		mapping mapInstVar: #archived to: #archived.
 		mapping mapInstVar: #web_url to: #html_url.
 		mapping mapInstVar: #topics to: #topics ].
+	^ reader nextAs: GLHProject"
+	
+	reader := generalReader on: aResult readStream.
+	
 	^ reader nextAs: GLHProject
 ]
 

--- a/src/GitHubHealth-Model-Importer/GithubModelImporter.class.st
+++ b/src/GitHubHealth-Model-Importer/GithubModelImporter.class.st
@@ -255,7 +255,8 @@ GithubModelImporter >> importFilesOfBranch: aBranch [
 	files
 		select: [ :file | file isKindOf: GLHFileDirectory ]
 		thenCollect: [ :file | 
-		self importDirectoryFiles: file OfBranch: aBranch ]
+		self importDirectoryFiles: file OfBranch: aBranch ].
+	^ files
 ]
 
 { #category : #api }

--- a/src/GitLabHealth-Model-Generator/GLHMetamodelGenerator.class.st
+++ b/src/GitLabHealth-Model-Generator/GLHMetamodelGenerator.class.st
@@ -26,7 +26,8 @@ Class {
 		'release',
 		'tag',
 		'issue',
-		'milestone'
+		'milestone',
+		'tRef'
 	],
 	#category : #'GitLabHealth-Model-Generator'
 }
@@ -74,7 +75,7 @@ GLHMetamodelGenerator class >> submetamodels [
 { #category : #branches }
 GLHMetamodelGenerator >> branchProperties [
 
-	branch property: #name type: #String
+	
 ]
 
 { #category : #changes }
@@ -213,6 +214,11 @@ GLHMetamodelGenerator >> defineHierarchy [
 	diff --|> #TNamedEntity.
 	job --|> #TNamedEntity.
 	note --|> #TNamedEntity.
+	
+	tRef --|> #TNamedEntity.
+	tRef <|-- commit .
+	tRef <|-- branch .
+	tRef <|-- tag .
 
 	change --|> #TNamedEntity.
 	change <|-- addition.
@@ -246,6 +252,8 @@ GLHMetamodelGenerator >> defineProperties [
 	self releaseProperties.
 	self issueProperties.
 	self milestoneProperties.
+	
+	self tRefProperties. 
 ]
 
 { #category : #definition }
@@ -282,6 +290,15 @@ GLHMetamodelGenerator >> defineRelations [
 	self mergeRequestsRelations.
 	self noteRelations.
 	self milestoneRelations. 
+]
+
+{ #category : #definition }
+GLHMetamodelGenerator >> defineTraits [
+	super defineTraits.
+	
+	tRef := builder newTraitNamed: #TRef comment: 'I''m representing a Git reference, that is a reference point in a repository''s history'.
+	"generate the identity isXXX method (see https://modularmoose.org/developers/create-new-metamodel/#generating-test-method)"
+	tRef withTesting.
 ]
 
 { #category : #diffs }
@@ -597,10 +614,17 @@ GLHMetamodelGenerator >> releaseRelations [
 	(release property: #project) *-<> (project property: #releases)
 ]
 
+{ #category : #'as yet unclassified' }
+GLHMetamodelGenerator >> tRefProperties [
+	"define the properties of a ref instance"
+	
+	tag property: #sha type: #String.
+	tag property: #name type: #String.
+]
+
 { #category : #tags }
 GLHMetamodelGenerator >> tagProperties [
 
-	tag property: #name type: #String.
 	tag property: #message type: #String.
 	tag property: #target type: #String.
 	tag property: #protected type: #Boolean.

--- a/src/GitLabHealth-Model-Importer/GitlabModelImporter.class.st
+++ b/src/GitLabHealth-Model-Importer/GitlabModelImporter.class.st
@@ -1003,7 +1003,9 @@ GitlabModelImporter >> importFilesOfBranch: aBranch [
 	files
 		select: [ :file | file isKindOf: GLHFileDirectory ]
 		thenCollect: [ :file | 
-		self importDirectoryFiles: file OfBranch: aBranch ]
+		self importDirectoryFiles: file OfBranch: aBranch ].
+	
+   ^files. 
 ]
 
 { #category : #'import - groups' }

--- a/src/GitLabHealth-Model-Importer/GitlabModelImporter.class.st
+++ b/src/GitLabHealth-Model-Importer/GitlabModelImporter.class.st
@@ -981,6 +981,12 @@ GitlabModelImporter >> importDirectoryFiles: aDirectoryFile OfBranch: aBranch [
 		self importDirectoryFiles: file OfBranch: aBranch ]
 ]
 
+{ #category : #'import - file' }
+GitlabModelImporter >> importFileWithPath: aPath ofProject: aGLHProject inBranch: aBranch [ 
+	self flag: 'imported file need need to be store inside the model'.
+	^ self repoApi repositories getRawFile: aPath ofProject: aGLHProject id withParams: {#ref -> aBranch name} asDictionary .
+]
+
 { #category : #'import - repositories' }
 GitlabModelImporter >> importFilesOfBranch: aBranch [
 

--- a/src/GitLabHealth-Model/GLHBranch.class.st
+++ b/src/GitLabHealth-Model/GLHBranch.class.st
@@ -25,14 +25,15 @@ A git branch
 
 | Name | Type | Default value | Comment |
 |---|
-| `name` | `String` | nil | |
+| `name` | `String` | nil | Basic name of the entity, not full reference.|
 
 "
 Class {
 	#name : #GLHBranch,
 	#superclass : #GLHEntity,
+	#traits : 'GLHTRef',
+	#classTraits : 'GLHTRef classTrait',
 	#instVars : [
-		'#name => FMProperty',
 		'#repository => FMOne type: #GLHRepository opposite: #branches',
 		'#files => FMMany type: #GLHFile opposite: #branch',
 		'#commits => FMMany type: #GLHCommit opposite: #branch'
@@ -98,20 +99,6 @@ GLHBranch >> filesGroup [
 	<generated>
 	<navigation: 'Files'>
 	^ MooseSpecializedGroup withAll: self files asSet
-]
-
-{ #category : #accessing }
-GLHBranch >> name [
-
-	<FMProperty: #name type: #String>
-	<generated>
-	^ name
-]
-
-{ #category : #accessing }
-GLHBranch >> name: anObject [
-	<generated>
-	name := anObject
 ]
 
 { #category : #accessing }

--- a/src/GitLabHealth-Model/GLHCommit.class.st
+++ b/src/GitLabHealth-Model/GLHCommit.class.st
@@ -21,8 +21,8 @@ a commit attached to a repository
 |---|
 | `branch` | `GLHCommit` | `commits` | `GLHBranch` | |
 | `childCommits` | `GLHCommit` | `parentCommits` | `GLHCommit` | |
-| `commitedMergeRequest` | `GLHCommit` | `mergeRequestCommit` | `GLHMergeRequest` | |
 | `commitedMergeRequest` | `GLHCommit` | `mergedCommit` | `GLHMergeRequest` | |
+| `commitedMergeRequest` | `GLHCommit` | `mergeRequestCommit` | `GLHMergeRequest` | |
 | `parentCommits` | `GLHCommit` | `childCommits` | `GLHCommit` | |
 | `squashedMergeRequest` | `GLHCommit` | `squashCommit` | `GLHMergeRequest` | |
 | `tag` | `GLHCommit` | `commit` | `GLHTag` | |
@@ -54,8 +54,8 @@ a commit attached to a repository
 Class {
 	#name : #GLHCommit,
 	#superclass : #GLHEntity,
-	#traits : 'FamixTNamedEntity',
-	#classTraits : 'FamixTNamedEntity classTrait',
+	#traits : 'FamixTNamedEntity + GLHTRef',
+	#classTraits : 'FamixTNamedEntity classTrait + GLHTRef classTrait',
 	#instVars : [
 		'#parent_ids => FMProperty defaultValue: \'OrderedCollection new\'',
 		'#id => FMProperty',

--- a/src/GitLabHealth-Model/GLHEntity.class.st
+++ b/src/GitLabHealth-Model/GLHEntity.class.st
@@ -43,3 +43,10 @@ GLHEntity >> isDeletion [
 	<generated>
 	^ false
 ]
+
+{ #category : #testing }
+GLHEntity >> isRef [
+
+	<generated>
+	^ false
+]

--- a/src/GitLabHealth-Model/GLHGroupGroup.class.st
+++ b/src/GitLabHealth-Model/GLHGroupGroup.class.st
@@ -40,3 +40,10 @@ GLHGroupGroup >> isQueryable [
 	<generated>
 	^ false
 ]
+
+{ #category : #testing }
+GLHGroupGroup >> isRef [
+
+	<generated>
+	^ false
+]

--- a/src/GitLabHealth-Model/GLHIssue.class.st
+++ b/src/GitLabHealth-Model/GLHIssue.class.st
@@ -27,8 +27,8 @@ an Issues help collaboration within a team to plan, track, and deliver work
 | `description` | `String` | nil | |
 | `due_date` | `Object` | nil | |
 | `id` | `Number` | nil | |
-| `name` | `String` | nil | Basic name of the entity, not full reference.|
 | `name` | `String` | nil | |
+| `name` | `String` | nil | Basic name of the entity, not full reference.|
 | `state` | `String` | nil | |
 | `updated_at` | `Object` | nil | |
 

--- a/src/GitLabHealth-Model/GLHTEntityCreator.trait.st
+++ b/src/GitLabHealth-Model/GLHTEntityCreator.trait.st
@@ -33,6 +33,13 @@ GLHTEntityCreator >> newBranch [
 ]
 
 { #category : #'entity creation' }
+GLHTEntityCreator >> newBranchNamed: aName [
+
+	<generated>
+	^ self add: (GLHBranch named: aName)
+]
+
+{ #category : #'entity creation' }
 GLHTEntityCreator >> newChange [
 
 	<generated>
@@ -240,6 +247,13 @@ GLHTEntityCreator >> newTag [
 
 	<generated>
 	^ self add: GLHTag new
+]
+
+{ #category : #'entity creation' }
+GLHTEntityCreator >> newTagNamed: aName [
+
+	<generated>
+	^ self add: (GLHTag named: aName)
 ]
 
 { #category : #'entity creation' }

--- a/src/GitLabHealth-Model/GLHTRef.trait.st
+++ b/src/GitLabHealth-Model/GLHTRef.trait.st
@@ -1,0 +1,33 @@
+"
+I'm representing a Git reference, that is a reference point in a repository's history
+
+## Properties
+======================
+
+| Name | Type | Default value | Comment |
+|---|
+| `name` | `String` | nil | Basic name of the entity, not full reference.|
+
+"
+Trait {
+	#name : #GLHTRef,
+	#traits : 'FamixTNamedEntity',
+	#classTraits : 'FamixTNamedEntity classTrait',
+	#category : #'GitLabHealth-Model-Traits'
+}
+
+{ #category : #meta }
+GLHTRef classSide >> annotation [
+
+	<FMClass: #TRef super: #Object>
+	<package: #'GitLabHealth-Model'>
+	<generated>
+	^ self
+]
+
+{ #category : #testing }
+GLHTRef >> isRef [
+
+	<generated>
+	^ true
+]

--- a/src/GitLabHealth-Model/GLHTag.class.st
+++ b/src/GitLabHealth-Model/GLHTag.class.st
@@ -24,19 +24,24 @@ a Tag is a reference to a specific point in the repository's history
 | `created_at` | `Object` | nil | |
 | `message` | `String` | nil | |
 | `name` | `String` | nil | |
+| `name` | `String` | nil | Basic name of the entity, not full reference.|
 | `protected` | `Boolean` | nil | |
+| `sha` | `String` | nil | |
 | `target` | `String` | nil | |
 
 "
 Class {
 	#name : #GLHTag,
 	#superclass : #GLHEntity,
+	#traits : 'GLHTRef',
+	#classTraits : 'GLHTRef classTrait',
 	#instVars : [
-		'#name => FMProperty',
 		'#message => FMProperty',
 		'#target => FMProperty',
 		'#protected => FMProperty',
 		'#created_at => FMProperty',
+		'#sha => FMProperty',
+		'#name => FMProperty',
 		'#commit => FMOne type: #GLHCommit opposite: #tag',
 		'#release => FMOne type: #GLHRelease opposite: #tag',
 		'#repository => FMOne type: #GLHRepository opposite: #tags'
@@ -160,6 +165,20 @@ GLHTag >> repositoryGroup [
 	<generated>
 	<navigation: 'Repository'>
 	^ MooseSpecializedGroup with: self repository
+]
+
+{ #category : #accessing }
+GLHTag >> sha [
+
+	<FMProperty: #sha type: #String>
+	<generated>
+	^ sha
+]
+
+{ #category : #accessing }
+GLHTag >> sha: anObject [
+	<generated>
+	sha := anObject
 ]
 
 { #category : #accessing }

--- a/src/GitLabHealth-Model/GLHUser.class.st
+++ b/src/GitLabHealth-Model/GLHUser.class.st
@@ -51,8 +51,8 @@ A GitLab User
 | `job_title` | `String` | nil | |
 | `linkedin` | `String` | nil | |
 | `location` | `String` | nil | |
-| `name` | `String` | nil | Basic name of the entity, not full reference.|
 | `name` | `String` | nil | |
+| `name` | `String` | nil | Basic name of the entity, not full reference.|
 | `organization` | `String` | nil | |
 | `pronouns` | `String` | nil | |
 | `public_email` | `String` | nil | |


### PR DESCRIPTION
Add new trait for Git reference in metamodel implemented for Commit, Tag and Branch.
Modify the Github importer to ensure newly independent Github-API implementation. 
Deprecate old Api