### PR TITLE
fix(GithubModelImporter): Store both group name and display name

### DIFF
--- a/src/GitHubHealth-Model-Importer/GithubModelImporter.class.st
+++ b/src/GitHubHealth-Model-Importer/GithubModelImporter.class.st
@@ -157,10 +157,11 @@ GithubModelImporter >> configureReaderForDiff: reader [
 GithubModelImporter >> configureReaderForGroup: reader [
 
 	super configureReaderForGroup: reader.
-	
-	reader
-		for: GLHGroup
-		do: [ :mapping | mapping mapInstVar: #web_url to: #html_url ]
+
+	reader for: GLHGroup do: [ :mapping |
+		mapping mapInstVar: #web_url to: #html_url.
+		mapping mapInstVar: #name to: #login.
+		mapping mapInstVar: #display_name to: #name ]
 ]
 
 { #category : #'private - configure reader' }
@@ -853,7 +854,7 @@ GithubModelImporter >> importPullRequestsOfProject: aProject [
 GithubModelImporter >> importRepositoriesOfGroup: groupResult [
 	"Github Repository = GLHProject"
 
-	| reposResult itemsPerPage pageNumber reposFound repos |
+	| itemsPerPage pageNumber reposFound repos |
 	itemsPerPage := 100.
 	pageNumber := 1.
 	('Extract all repositories of ' , groupResult name) recordInfo.
@@ -868,7 +869,7 @@ GithubModelImporter >> importRepositoriesOfGroup: groupResult [
 	reposFound addAll: repos.
 	[ repos size = itemsPerPage ] whileTrue: [
 		pageNumber := pageNumber + 1.
-		('Extract issues from ' , reposFound size printString , ' to '
+		('Extract commits from ' , reposFound size printString , ' to '
 		 , (reposFound size + itemsPerPage) printString) recordInfo.
 		repos := self parseArrayOfProject: (self repoApi organizations
 				        getRepositoriesOfOrganization: groupResult name
@@ -876,8 +877,6 @@ GithubModelImporter >> importRepositoriesOfGroup: groupResult [
 				        page: pageNumber).
 		reposFound addAll: repos ].
 
-	reposResult := self repoApi organizations
-		               getRepositoriesOfOrganization: groupResult name.
 	groupResult projects addAll: reposFound.
 	self glhModel addAll: groupResult projects.
 	groupResult projects do: [ :project |

--- a/src/GitLabHealth-Model-Generator/GLHMetamodelGenerator.class.st
+++ b/src/GitLabHealth-Model-Generator/GLHMetamodelGenerator.class.st
@@ -363,7 +363,8 @@ GLHMetamodelGenerator >> groupProperties [
 	group property: #web_url type: #String.
 	group property: #description type: #String.
 	group property: #visibility type: #String.
-	group property: #avatar_url type: #String
+	group property: #avatar_url type: #String.
+	group property: #display_name type: #String
 ]
 
 { #category : #issues }

--- a/src/GitLabHealth-Model-Importer/GitlabModelImporter.class.st
+++ b/src/GitLabHealth-Model-Importer/GitlabModelImporter.class.st
@@ -279,7 +279,9 @@ GitlabModelImporter >> configureReaderForGroup: reader [
 	super configureReaderForGroup: reader.
 
 	reader for: GLHGroup do: [ :mapping |
-		(mapping mapInstVar: #projects) valueSchema: #ArrayOfProject ]
+		(mapping mapInstVar: #projects) valueSchema: #ArrayOfProject.
+		mapping mapInstVar: #name to: #path.
+		mapping mapInstVar: #display_name to: #name ]
 ]
 
 { #category : #'private - configure reader' }

--- a/src/GitLabHealth-Model/GLHGroup.class.st
+++ b/src/GitLabHealth-Model/GLHGroup.class.st
@@ -23,6 +23,7 @@ A GitLab Group
 |---|
 | `avatar_url` | `String` | nil | |
 | `description` | `String` | nil | |
+| `display_name` | `String` | nil | |
 | `id` | `Number` | nil | |
 | `name` | `String` | nil | Basic name of the entity, not full reference.|
 | `visibility` | `String` | nil | |
@@ -35,14 +36,15 @@ Class {
 	#traits : 'FamixTNamedEntity',
 	#classTraits : 'FamixTNamedEntity classTrait',
 	#instVars : [
-		'#id => FMProperty',
-		'#web_url => FMProperty',
-		'#description => FMProperty',
-		'#visibility => FMProperty',
 		'#avatar_url => FMProperty',
+		'#description => FMProperty',
+		'#display_name => FMProperty',
+		'#group => FMOne type: #GLHGroup opposite: #subGroups',
+		'#id => FMProperty',
 		'#projects => FMMany type: #GLHProject opposite: #group',
 		'#subGroups => FMMany type: #GLHGroup opposite: #group',
-		'#group => FMOne type: #GLHGroup opposite: #subGroups'
+		'#visibility => FMProperty',
+		'#web_url => FMProperty'
 	],
 	#category : #'GitLabHealth-Model-Entities'
 }
@@ -101,6 +103,20 @@ GLHGroup >> description [
 GLHGroup >> description: anObject [
 	<generated>
 	description := anObject
+]
+
+{ #category : #accessing }
+GLHGroup >> display_name [
+
+	<FMProperty: #display_name type: #String>
+	<generated>
+	^ display_name
+]
+
+{ #category : #accessing }
+GLHGroup >> display_name: anObject [
+	<generated>
+	display_name := anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
For GitHub: `GLHGroup`'s name now corresponds to the `login` (what's in the address bar), and the new property `display_name` stores the pretty name found on the group's home page.

Still need to check how that goes for GitLab and BitBucket, plus adding tests.